### PR TITLE
(maint) whitespace cleanup

### DIFF
--- a/lib/puppet/type/panos_address.rb
+++ b/lib/puppet/type/panos_address.rb
@@ -7,24 +7,24 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/devices/entry/vsys/entry/address',
   features: ['remote_resource'],
-  attributes:   {
-    name:        {
+  attributes: {
+    name: {
       type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
       desc:      'The display-name of the address.',
       behaviour: :namevar,
       xpath:      'string(@name)',
     },
-    ensure:      {
+    ensure: {
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
     },
-    description:    {
+    description: {
       type:      'Optional[String]',
       desc:      'Provide a description of this address.',
       xpath:     'description/text()',
     },
-    ip_netmask:    {
+    ip_netmask: {
       type:      'Optional[String]',
       desc:      <<DESC,
         Provide an IP address or a network using the slash notation (Ex. 192.168.80.150 or 192.168.80.0/24).
@@ -33,7 +33,7 @@ Puppet::ResourceApi.register_type(
 DESC
       xpath:     'ip-netmask/text()',
     },
-    ip_range:    {
+    ip_range: {
       type:      'Optional[String]',
       desc:      <<DESC,
         Provide an IP address range (Ex. 10.0.0.1-10.0.0.4).
@@ -42,12 +42,12 @@ DESC
 DESC
       xpath:     'ip-range/text()',
     },
-    fqdn:    {
+    fqdn: {
       type:      'Optional[String]',
       desc:      'Provide a fully qualified domain name. You need to provide exactly one of ip_netmask, ip_range, or fqdn.',
       xpath:     'fqdn/text()',
     },
-    tags:    {
+    tags: {
       type:      'Array[String]',
       desc:      'The Palo Alto tags to apply to this address. Do not confuse this with the `tag` metaparameter used to filter resource application.',
       default:   [],

--- a/lib/puppet/type/panos_address_group.rb
+++ b/lib/puppet/type/panos_address_group.rb
@@ -7,34 +7,34 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/devices/entry/vsys/entry/address-group',
   features: ['remote_resource'],
-  attributes:   {
-    name:        {
+  attributes: {
+    name: {
       type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
       desc:      'The display-name of the address-group.',
       behaviour: :namevar,
       xpath:      'string(@name)',
     },
-    ensure:      {
+    ensure: {
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
     },
-    description:    {
+    description: {
       type:      'Optional[String]',
       desc:      'Provide a description of this address-group.',
       xpath:     'description/text()',
     },
-    type:    {
+    type: {
       type:      'Enum["static", "dynamic"]',
       desc:      'A `static` or `dynamic` address-group.',
       xpath:     'local-name(static|dynamic)',
     },
-    static_members:    {
+    static_members: {
       type:      'Optional[Array[String]]',
       desc:      'An array of `panos_address`, or `panos_address_group` that form this group. Used only when type is static.',
       xpath_array:     'static/member/text()',
     },
-    dynamic_filter:    {
+    dynamic_filter: {
       type:      'Optional[String]',
       desc:      <<DESC,
       To create a dynamic address group, use the match criteria to assemble the members to be included in the group.
@@ -44,7 +44,7 @@ Puppet::ResourceApi.register_type(
 DESC
       xpath:      'dynamic/filter/text()',
     },
-    tags:    {
+    tags: {
       type:      'Array[String]',
       desc:      'The Palo Alto tags to apply to this address-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
       default:   [],

--- a/lib/puppet/type/panos_admin.rb
+++ b/lib/puppet/type/panos_admin.rb
@@ -7,19 +7,19 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/mgt-config/users',
   features: ['remote_resource'],
-  attributes:   {
-    name:        {
+  attributes: {
+    name: {
       type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
       desc:      'The username.',
       behaviour: :namevar,
       xpath:      'string(@name)',
     },
-    ensure:      {
+    ensure: {
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
     },
-    password_hash:    {
+    password_hash: {
       type:      'Optional[String]',
       desc:      'Provide a password hash.',
       xpath:     'phash/text()',
@@ -30,17 +30,17 @@ Puppet::ResourceApi.register_type(
       default:  false,
       xpath:    'client-certificate-only/text()',
     },
-    ssh_key:    {
+    ssh_key: {
       type:      'Optional[String]',
       desc:      'Provide the users public key in plain text',
       xpath:     'public-key/text()',
     },
-    role:       {
+    role: {
       type:     'Enum["superuser", "superreader", "devicereader", "custom"]',
       desc:     'Specify the access level for the administrator',
       xpath:    'local-name(permissions/role-based/*[1])',
     },
-    role_profile:    {
+    role_profile: {
       type:     'Optional[String]',
       desc:     'Specify the role profile for the user',
       xpath:    'permissions/role-based/custom/profile/text()',

--- a/lib/puppet/type/panos_commit.rb
+++ b/lib/puppet/type/panos_commit.rb
@@ -6,8 +6,8 @@ Puppet::ResourceApi.register_type(
       When evaluated, this resource commits all outstanding changes in the target device's configuration to the active configuration. It is automatically scheduled after all other PANOS resources.
     EOS
   features: ['remote_resource'],
-  attributes:   {
-    name:        {
+  attributes: {
+    name: {
       type:      'Enum["commit"]',
       desc:      'The name of the resource you want to manage. Can only be "commit".',
       behaviour: :namevar,

--- a/lib/puppet/type/panos_service.rb
+++ b/lib/puppet/type/panos_service.rb
@@ -7,39 +7,39 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/devices/entry/vsys/entry/service',
   features: ['remote_resource'],
-  attributes:   {
-    name:         {
+  attributes: {
+    name: {
       type:       'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
       desc:       'The display-name of the service.',
       xpath:      'string(@name)',
       behaviour:  :namevar,
     },
-    ensure:        {
+    ensure: {
       type:       'Enum[present, absent]',
       desc:       'Whether this resource should be present or absent on the target system.',
       default:    'present',
     },
-    description:  {
+    description: {
       type:      'Optional[String]',
       desc:      'Provide a description of this service.',
       xpath:     'description/text()',
     },
-    protocol:    {
+    protocol: {
       type:      'Enum["tcp", "udp"]',
       desc:      'The network protocol ther service runs on.',
       xpath:     'local-name(protocol/*[1])',
     },
-    dest_port:    {
+    dest_port: {
       type:      'Optional[String]',
       desc:      'If not specified, src_port must be. Port can be a single port number, a range `1-65535`, or comma separated values  `80, 8080, 443`',
       xpath:      'protocol/*[1]/port/text()',
     },
-    src_port:    {
+    src_port: {
       type:      'Optional[String]',
       desc:      'If not specified, dest_port must be. Port can be a single port number, a range `1-65535`, or comma separated values  `80, 8080, 443`',
       xpath:      'protocol/*[1]/source-port/text()',
     },
-    tags:        {
+    tags: {
       type:      'Array[String]',
       desc:      'The Palo Alto tags to apply to this address-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
       default:   [],

--- a/lib/puppet/type/panos_service_group.rb
+++ b/lib/puppet/type/panos_service_group.rb
@@ -7,24 +7,24 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/devices/entry/vsys/entry/service-group',
   features: ['remote_resource'],
-  attributes:   {
-    name:        {
+  attributes: {
+    name: {
       type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
       desc:      'The display-name of the service-group.',
       behaviour: :namevar,
       xpath:      'string(@name)',
     },
-    ensure:      {
+    ensure: {
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
     },
-    services:    {
+    services: {
       type:      'Array[String]',
       desc:      'An array of `panos_service`, or `panos_service_group` that form this group.',
       xpath_array:     'members/member/text()',
     },
-    tags:    {
+    tags: {
       type:      'Array[String]',
       desc:      'The Palo Alto tags to apply to this service-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
       default:   [],

--- a/lib/puppet/type/panos_tag.rb
+++ b/lib/puppet/type/panos_tag.rb
@@ -7,24 +7,24 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/devices/entry/vsys/entry/tag',
   features: ['remote_resource'],
-  attributes:   {
-    name:         {
+  attributes: {
+    name: {
       type:       'String',
       desc:       'The display-name of the tag.',
       xpath:      'string(@name)',
       behaviour:  :namevar,
     },
-    ensure:        {
+    ensure: {
       type:       'Enum[present, absent]',
       desc:       'Whether this resource should be present or absent on the target system.',
       default:    'present',
     },
-    color:        {
+    color: {
       type:       'Optional[String]',
       desc:       'The color of the tag',
       xpath:      'color/text()',
     },
-    comments:  {
+    comments: {
       type:      'Optional[String]',
       desc:      'Provide a comment for this tag.',
       xpath:     'comments/text()',

--- a/lib/puppet/type/panos_zone.rb
+++ b/lib/puppet/type/panos_zone.rb
@@ -7,34 +7,34 @@ Puppet::ResourceApi.register_type(
     EOS
   base_xpath: '/config/devices/entry/vsys/entry/zone',
   features: ['remote_resource'],
-  attributes:   {
-    name:         {
+  attributes: {
+    name: {
       type:            'String',
       desc:            'The display-name of the zone.',
       xpath:           'string(@name)',
       behaviour:       :namevar,
     },
-    ensure:        {
+    ensure: {
       type:            'Enum[present, absent]',
       desc:            'Whether this resource should be present or absent on the target system.',
       default:         'present',
     },
-    network:        {
+    network: {
       type:            'Optional[Enum["tap","virtual-wire","layer2","layer3"]]',
       desc:            'The network type of this zone.',
       xpath:           'local-name(network/*)',
     },
-    interfaces:     {
+    interfaces: {
       type:            'Optional[Array[String]]',
       desc:            'The interfaces used by this zone.',
       xpath_array:     'network//member/text()',
     },
-    zone_protection_profile:        {
+    zone_protection_profile: {
       type:            'Optional[String]',
       desc:            'The protection profile of the zone.',
       xpath:           'network/zone-protection-profile/text()',
     },
-    log_setting:        {
+    log_setting: {
       type:            'Optional[String]',
       desc:            'The log setting of the zone.',
       xpath:           'network/log-setting/text()',

--- a/spec/unit/puppet/provider/panos_address/panos_address_spec.rb
+++ b/spec/unit/puppet/provider/panos_address/panos_address_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Puppet::Provider::PanosAddress::PanosAddress do
     },
     {
       desc:   'an example containing range_address',
-      attrs:  {
+      attrs: {
         name:         'range_address',
         ensure:       'present',
         description:  'some address',
@@ -129,7 +129,7 @@ RSpec.describe Puppet::Provider::PanosAddress::PanosAddress do
     },
     {
       desc: 'an example containing fqdn_address',
-      attrs:  {
+      attrs: {
         name:         'fqdn_address',
         ensure:       'present',
         description:  'some address',

--- a/spec/unit/puppet/provider/panos_admin/panos_admin_spec.rb
+++ b/spec/unit/puppet/provider/panos_admin/panos_admin_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Puppet::Provider::PanosAdmin::PanosAdmin do
     },
     {
       desc: 'an account with client certificate enabled',
-      attrs:  {
+      attrs: {
         name: 'cert_enabled',
         ensure: 'present',
         client_certificate_only: true,
@@ -147,7 +147,7 @@ RSpec.describe Puppet::Provider::PanosAdmin::PanosAdmin do
     },
     {
       desc: 'an account with client certificate disabled',
-      attrs:  {
+      attrs: {
         name: 'cert_enabled',
         ensure: 'present',
         client_certificate_only: false,

--- a/spec/unit/puppet/provider/panos_provider_spec.rb
+++ b/spec/unit/puppet/provider/panos_provider_spec.rb
@@ -11,23 +11,23 @@ RSpec.describe Puppet::Provider::PanosProvider do
 
   let(:attrs) do
     {
-      name:        {
+      name: {
         type:      'String',
         xpath:      'string(@name)',
       },
-      description:    {
+      description: {
         type:      'Optional[String]',
         xpath:     'description/text()',
       },
-      is_enabled:    {
+      is_enabled: {
         type:      'Boolean',
         xpath:     'isenabled/text()',
       },
-      maybe_enabled:    {
+      maybe_enabled: {
         type:      'Optional[Boolean]',
         xpath:     'enabled/text()',
       },
-      tags:    {
+      tags: {
         type:      'Array[String]',
         xpath_array:     'tag/member/text()',
       },


### PR DESCRIPTION
Replace `%r{: *\{}` with `': {'` in all files.