### PR TITLE
(FM-7189) Add a PANOS Arbitrary Command Type and Provider

### DIFF
--- a/lib/puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands.rb
+++ b/lib/puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands.rb
@@ -1,0 +1,77 @@
+require 'puppet/resource_api/simple_provider'
+require 'rexml/xpath'
+require 'builder'
+
+# provider to handle arbitrary configuration commands against a PANOS device using the Resource API.
+class Puppet::Provider::PanosArbitraryCommands::PanosArbitraryCommands < Puppet::ResourceApi::SimpleProvider
+  # to ensure that the manifest xml matches the API format
+  #
+  # e.g.
+  #     <entry admin='admin'>
+  #       <foo>bar</bar>
+  #     </entry>
+  # becomes:
+  #     <entry><foo>bar</bar></entry>
+  def canonicalize(_context, resources)
+    resources.each do |resource|
+      resource[:xml] = str_from_xml(resource[:xml])
+    end
+
+    resources
+  end
+
+  def get(context, xpaths = nil)
+    return [] if xpaths.nil?
+    results = []
+    config = context.device.get_config('/config/devices/entry/vsys/entry/' + xpaths.first) unless xpaths.first.nil?
+    if xpaths.first
+      config.elements.collect('/response/result') do |entry| # rubocop:disable Style/CollectionMethods
+        xml = str_from_xml(entry.to_s)
+
+        results << {
+          xpath:  xpaths.first,
+          ensure: 'present',
+          xml:    xml,
+        }
+      end
+    end
+    results
+  end
+
+  def create(context, xpath, should)
+    begin
+      should = REXML::Document.new should[:xml]
+    rescue REXML::ParseException => parse_exception
+      raise Puppet::ResourceError, parse_exception.message
+    end
+
+    context.device.set_config('/config/devices/entry/vsys/entry/' + xpath, should)
+  end
+
+  def update(context, xpath, should)
+    begin
+      should = REXML::Document.new should[:xml]
+    rescue REXML::ParseException => parse_exception
+      raise Puppet::ResourceError, parse_exception.message
+    end
+
+    context.device.edit_config('/config/devices/entry/vsys/entry/' + xpath, should)
+  end
+
+  def delete(context, xpath)
+    context.device.delete_config('/config/devices/entry/vsys/entry/' + xpath)
+  end
+
+  def str_from_xml(xml)
+    xml.to_s
+       .gsub(%r{<result.*?[^>)]>}, '') # cleaning out the start of the result tags
+       .gsub(%r{</result>}, '') # cleaning the closing result tags
+       .gsub(%r{admin=(?:'|")[a-zA-Z0-9]*(?:'|")}, '') # removing the `admin` attributes
+       .gsub(%r{time=(?:'|")\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}(?:'|")}, '') # removing the `time` attributes
+       .gsub(%r{dirtyId=(?:'|")\d*(?:'|")}, '') # removing the `dirtyId` attributes
+       .gsub(%r{\n(\s*[^<])?}, '') # removing new lines and extra spaces
+       .tr("'", '"') # replacing the \' with "
+       .gsub(%r{\s{2,}}, ' ') # removing extra spaces
+       .gsub(%r{\s*(/)?>}, '\1>') # cleaning the extra spaces before a close `>` and self close `/>`
+  end
+end

--- a/lib/puppet/type/panos_arbitrary_commands.rb
+++ b/lib/puppet/type/panos_arbitrary_commands.rb
@@ -1,0 +1,28 @@
+require 'puppet/resource_api'
+
+Puppet::ResourceApi.register_type(
+  name: 'panos_arbitrary_commands',
+  docs: <<-EOS,
+      This type provides Puppet with the capabilities to execute arbitrary configuration commands on Palo Alto devices.
+    EOS
+  features: ['simple_get_filter', 'remote_resource', 'canonicalize'],
+  attributes: {
+    ensure: {
+      type:    'Enum[present, absent]',
+      desc:    'Whether this resource should be present or absent on the target system.',
+      default: 'present',
+    },
+    xpath: {
+      type:      'String',
+      desc:      'The PANOS API XPath on which to set the :xml.',
+      behaviour: :namevar,
+    },
+    xml:  {
+      type:      'String',
+      desc:      'The XML to be set. Use: file(path/to/file.xml).',
+    },
+  },
+  autobefore: {
+    panos_commit: 'commit',
+  },
+)

--- a/spec/fixtures/basics.pp
+++ b/spec/fixtures/basics.pp
@@ -190,6 +190,19 @@ panos_security_policy_rule  {
     disable =>  true;
 }
 
+panos_arbitrary_commands  {
+  'application-group':
+    ensure    => 'present',
+    xml       => '<application-group>
+                    <entry name="Application Group">
+                      <members>
+                        <member>1c-enterprise</member>
+                      </members>
+                    </entry>
+                  </application-group>';
+    # xml       => file('MODULENAME/file.xml');
+}
+
 panos_commit {
   'commit':
     commit => true

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -13,3 +13,11 @@ RSpec.shared_examples 'munge(entry)' do |test_data, provider|
     end
   end
 end
+
+RSpec.shared_examples 'str_from_xml(xml)' do |test_data, provider|
+  test_data.each do |test|
+    it "executes correct conversion for `#{test[:desc]}`" do
+      expect(provider.str_from_xml(test[:raw_xml])).to eq(test[:parsed_xml])
+    end
+  end
+end

--- a/spec/unit/puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands_spec.rb
+++ b/spec/unit/puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands_spec.rb
@@ -1,0 +1,218 @@
+require 'spec_helper'
+require 'support/shared_examples'
+
+module Puppet::Provider::PanosArbitraryCommands; end
+require 'puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands'
+
+RSpec.describe Puppet::Provider::PanosArbitraryCommands::PanosArbitraryCommands do
+  subject(:provider) { described_class.new }
+
+  let(:context) { instance_double('Puppet::ResourceApi::BaseContext', 'context') }
+  let(:device) { instance_double('Puppet::Util::NetworkDevice::Panos::Device', 'device') }
+  let(:typedef) { instance_double('Puppet::ResourceApi::TypeDefinition', 'typedef') }
+
+  let(:example_data) do
+    REXML::Document.new <<EOF
+      <response>
+        <result>
+          #{test_entry_1}
+        </result>
+      </response>
+EOF
+  end
+  let(:test_entry_1) do
+    String.new <<EOF
+    <entry name="foo">
+      <indent>bar</indent>
+      <foo>
+        <bar/>
+      </foo>
+    </entry>
+EOF
+  end
+
+  let(:parsed_xml) { '<entry name="foo"><indent>bar</indent><foo><bar/></foo></entry>' }
+
+  let(:resource_data) do
+    [
+      {
+        xpath:  'foo',
+        xml:    parsed_xml,
+        ensure: 'present',
+      },
+    ]
+  end
+  let(:multiple_resource_data) do
+    [
+      {
+        xpath:  'foo',
+        xml:    parsed_xml,
+        ensure: 'present',
+      },
+      {
+        xpath:  'bar',
+        xml:    parsed_xml,
+        ensure: 'present',
+      },
+    ]
+  end
+
+  let(:error_resource_data) do
+    [
+      {
+        xpath:  'foo',
+        xml:    '<entry><foo></entry>',
+        ensure: 'present',
+      },
+    ]
+  end
+
+  before(:each) do
+    allow(context).to receive(:device).with(no_args).and_return(device)
+  end
+
+  describe '#canonicalize' do
+    context 'when `canonicalize` is called with one resource' do
+      it 'calls the `str_from_xml` once' do
+        expect(provider).to receive(:str_from_xml).once # rubocop:disable RSpec/SubjectStub
+
+        expect(provider.canonicalize(context, resource_data)).to eq(resource_data)
+      end
+    end
+    context 'when `canonicalize` is called with more than one resource' do
+      it 'calls the `str_from_xml` enough times' do
+        expect(provider).to receive(:str_from_xml).twice # rubocop:disable RSpec/SubjectStub
+
+        expect(provider.canonicalize(context, multiple_resource_data)).to eq(multiple_resource_data)
+      end
+    end
+  end
+
+  describe '#get' do
+    context 'when `names` is nil' do
+      it 'returns empty array' do
+        expect(provider.get(context, nil)).to eq([])
+      end
+    end
+    context 'when `names` is not nil' do
+      it 'returns resource' do
+        allow(device).to receive(:get_config).with('/config/devices/entry/vsys/entry/foo').and_return(example_data)
+        allow(provider).to receive(:str_from_xml).and_return(parsed_xml) # rubocop:disable RSpec/SubjectStub
+
+        expect(provider.get(context, ['foo'])).to eq(resource_data)
+      end
+    end
+    context 'when device issues an error' do
+      it 'allows for device errors to bubble up' do
+        allow(device).to receive(:get_config).with('/config/devices/entry/vsys/entry/some').and_raise(Puppet::ResourceError, 'Some Error Message')
+
+        expect { provider.get(context, ['some']) }.to raise_error Puppet::ResourceError
+      end
+    end
+  end
+
+  describe '#create' do
+    context 'when xml is valid' do
+      it 'does not produce an error' do
+        allow(REXML::Document).to receive(:new).with(parsed_xml).and_return(example_data)
+        allow(device).to receive(:set_config).with('/config/devices/entry/vsys/entry/foo', example_data)
+
+        expect { provider.create(context, 'foo', resource_data[0]) }.not_to raise_error
+      end
+    end
+    context 'when xml is invalid' do
+      it 'produces an error' do
+        allow(REXML::Document).to receive(:new).with('<entry><foo></entry>').and_raise(REXML::ParseException.new('Missing end tag for "foo" (got "entry")'))
+
+        expect { provider.create(context, 'foo', error_resource_data[0]) }.to raise_error(Puppet::ResourceError, 'Missing end tag for "foo" (got "entry")')
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when xml is valid' do
+      it 'does not produce an error' do
+        allow(REXML::Document).to receive(:new).with(parsed_xml).and_return(example_data)
+        allow(device).to receive(:edit_config).with('/config/devices/entry/vsys/entry/foo', example_data)
+
+        expect { provider.update(context, 'foo', resource_data[0]) }.not_to raise_error
+      end
+    end
+    context 'when xml is invalid' do
+      it 'produces an error' do
+        allow(REXML::Document).to receive(:new).with('<entry><foo></entry>').and_raise(REXML::ParseException.new('Missing end tag for "foo" (got "entry")'))
+
+        expect { provider.update(context, 'foo', error_resource_data[0]) }.to raise_error(Puppet::ResourceError, 'Missing end tag for "foo" (got "entry")')
+      end
+    end
+  end
+
+  describe '#delete' do
+    it 'calls provider functions' do
+      expect(device).to receive(:delete_config).with('/config/devices/entry/vsys/entry/foo')
+
+      provider.delete(context, resource_data[0][:xpath])
+    end
+  end
+
+  test_data_for_str_from_xml = [
+    {
+      desc:       'an example with `result` tags',
+      raw_xml:    '<result total-count=\'10\'><entry></entry></result>',
+      parsed_xml: '<entry></entry>',
+    },
+    {
+      desc:       'an example with `admin` attributes',
+      raw_xml:    '<entry admin=\'foo\'><indented admin=\'bar\'></indented></entry>',
+      parsed_xml: '<entry><indented></indented></entry>',
+    },
+    {
+      desc:       'an example with `time` attributes',
+      raw_xml:    '<entry time=\'2014/12/23 12:00:00\'><indented time=\'2014/12/23 12:00:00\'></indented></entry>',
+      parsed_xml: '<entry><indented></indented></entry>',
+    },
+    {
+      desc:       'an example with `dirtyId` attributes',
+      raw_xml:    '<entry dirtyId=\'203\'><indented dirtyId=\'203\'></indented></entry>',
+      parsed_xml: '<entry><indented></indented></entry>',
+    },
+    {
+      desc:       'an example with `name` attributes',
+      raw_xml:    '<entry name=\'foo\'></entry>',
+      parsed_xml: '<entry name="foo"></entry>',
+    },
+    {
+      desc:       'an example with more than one space',
+      raw_xml:    '<entry   name=\'foo\'></entry>',
+      parsed_xml: '<entry name="foo"></entry>',
+    },
+    {
+      desc:       'an example with spaces before the closing tags `>`',
+      raw_xml:    '<entry   name=\'foo\'   ></entry   >',
+      parsed_xml: '<entry name="foo"></entry>',
+    },
+    {
+      desc:       'an example with spaces before the self-closing tags `/>`',
+      raw_xml:    '<entry   name=\'foo\'   ><bar    /></entry   >',
+      parsed_xml: '<entry name="foo"><bar/></entry>',
+    },
+    {
+      desc:       'an example with new lines',
+      raw_xml:    '<entry name=\'foo\'>
+                  </entry>',
+      parsed_xml: '<entry name="foo"></entry>',
+    },
+    {
+      desc:       'an example with tabs',
+      raw_xml:    '<entry name=\'foo\'>
+                    <indent>bar</indent>
+                    <foo>
+                      <bar/>
+                    </foo>
+                  </entry>',
+      parsed_xml: '<entry name="foo"><indent>bar</indent><foo><bar/></foo></entry>',
+    },
+  ]
+
+  include_examples 'str_from_xml(xml)', test_data_for_str_from_xml, described_class.new
+end

--- a/spec/unit/puppet/type/panos_arbitrary_commands_spec.rb
+++ b/spec/unit/puppet/type/panos_arbitrary_commands_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'puppet/type/panos_arbitrary_commands'
+
+RSpec.describe 'the panos_arbitrary_commands type' do
+  it 'loads' do
+    expect(Puppet::Type.type(:panos_arbitrary_commands)).not_to be_nil
+  end
+end


### PR DESCRIPTION
Allows for XML to be ran on the device by supplying an xpath along with the XML entries.