### PR TITLE
(FM-7298) Compatibility changes for PANOS security policy rules

### DIFF
--- a/lib/puppet/type/panos_security_policy_rule.rb
+++ b/lib/puppet/type/panos_security_policy_rule.rb
@@ -9,8 +9,8 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
-      desc:      'The display-name of the security-policy-rule.',
+      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
+      desc:      'The display-name of the security-policy-rule. Restricted to 31 characters on PAN-OS version < 8.1.0.',
       behaviour: :namevar,
       xpath:     'string(@name)',
     },

--- a/spec/fixtures/create.pp
+++ b/spec/fixtures/create.pp
@@ -169,51 +169,107 @@ panos_nat_policy {
 panos_security_policy_rule  {
   'minimal':
     ensure => 'present';
-  'Default security policy rule':
-    ensure       =>  'present';
-  'Adding a group policy value':
-    ensure       =>  'present',
-    action       =>  'deny',
-    profile_type =>  'group',
-    # group_profile       => 'Custom profile type',
-    log_start    =>  true,
-    qos_type     =>  'ip-dscp',
-    ip_dscp      =>  'af11';
-  'Adding custom profiles':
-    ensure                    =>  'present',
-    profile_type              =>  'profiles',
-    anti_virus_profile        =>  'none',
-    vulnerability_profile     =>  'default',
-    spyware_profile           =>  'default',
-    url_filtering_profile     =>  'default',
-    file_blocking_profile     =>  'none',
-    # data_filtering_profile  =>  'Custom profile type',
-    wildfire_analysis_profile =>  'default';
-  'QoS Marking settings':
-    ensure   =>  'present',
-    qos_type =>  'follow-c2s-flow';
-  'All the options':
-    ensure                             => 'present',
-    rule_type                          => 'interzone',
-    description                        => 'This is managed by Puppet.',
-    # tags         => ['puppet', 'test', 'all', 'options'],
-    # source_zones => ['Custom Zone 1', 'Custom Zone 2'],
-    source_address                     =>  ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
-    # source_users    => ['Custom User', 'Custom User 2'],
-    # hip_profiles      => ['Custom HIP 1', 'Customer HIP 2'],
-    # destination_zones => ['Custom Zone 1', 'Custom Zone 2'],
-    destination_address                =>  ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
-    applications                       => ['activesync'],
-    services                           => ['service-http'],
-    categories                         => ['games', 'home-and-garden'],
-    action                             => 'reset-client',
-    icmp_unreachable                   => false,
-    # log_setting         => 'custom log settings',
-    # schedule_profile    => 'custom schedule',
-    disable_server_response_inspection =>  false;
-  'Disable a Security Policy Rule':
-    ensure  => 'present',
-    disable =>  true;
+  'description':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.';
+  'universal':
+    ensure    => 'present',
+    rule_type => 'universal';
+  'intrazone':
+    ensure    => 'present',
+    rule_type => 'intrazone';
+  'interzone':
+    ensure    => 'present',
+    rule_type => 'interzone';
+  'tags':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    # tags         =>  ['puppet', 'managed'],
+    rule_type   => 'universal';
+  'sources':
+    ensure         => 'present',
+    description    => 'This is managed by Puppet.',
+    # source_zones => ['custom zone 1', 'custom zone 2'],
+    source_address => ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
+    rule_type      => 'universal';
+  'destination':
+    ensure              => 'present',
+    description         => 'This is managed by Puppet.',
+    destination_zones   => ['multicast'],
+    # destination_zones => ['custom zone 3', 'custom zone 4'],
+    source_address      => ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
+    destination_address => ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
+    rule_type           => 'universal';
+  'users':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    source_users => ['pre-logon'],
+    # source_users  =>  ['custom user 1', 'customer user 2'],
+    rule_type    => 'universal';
+  'hip-profiles':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    # tags         =>  ['puppet', 'managed'],
+    hip_profiles => ['no-hip'],
+    # hip_profiles  =>  ['custom profile 1', 'custom profile 2'],
+    rule_type    => 'universal';
+  'applications':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    hip_profiles => ['no-hip'],
+    applications => ['1c-enterprise', '1und1-mail', '4shared'],
+    rule_type    => 'universal';
+  'services':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    services    => ['any'],
+    categories  => ['adult', 'auctions', 'content-delivery-networks'],
+    rule_type   => 'universal';
+  'actions':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    action      => 'deny',  
+    rule_type   => 'universal';
+  'log-settings':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    log_start   => true,
+    log_end     => false;
+    # log_setting   => 'custom log forwarding profile';
+  'profile-setting-profiles':
+    ensure                => 'present',
+    description           => 'This is managed by Puppet.',
+    profile_type          => 'profiles',
+    anti_virus_profile    => 'default',
+    vulnerability_profile => 'strict',
+    spyware_profile       => 'strict',
+    url_filtering_profile => 'default';
+    # file_blocking_profile => 'custom file blocking profile',
+    # data_filtering_profile  =>  'custom data filtering profile',
+    # wildfire_analysis_profile  =>  'custom analysis profile';
+  'profile-setting-group':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    profile_type => 'group';
+    # group_profile => 'custom group profile';
+  'other-settings':
+    ensure                              =>  'present',
+    description                         =>  'This is managed by Puppet.',
+    # schedule_profile  => 'custom schedule profile',
+    qos_type                            => 'follow-c2s-flow',
+    disable_server_response_inspection  =>  true;
+  'ip-dscp-settings':
+    ensure                              =>  'present',
+    description                         =>  'This is managed by Puppet.',
+    qos_type                            => 'ip-dscp',
+    ip_dscp                             =>  'cs0',
+    disable_server_response_inspection  =>  true;
+  'ip-precedence-settings':
+    ensure                              =>  'present',
+    description                         =>  'This is managed by Puppet.',
+    qos_type                            =>  'ip-precedence',
+    ip_precedence                       =>  'cs0',
+    disable_server_response_inspection  =>  true;
 }
 
 panos_commit {

--- a/spec/fixtures/delete.pp
+++ b/spec/fixtures/delete.pp
@@ -41,8 +41,44 @@ panos_nat_policy {
 }
 
 panos_security_policy_rule  {
-  'Default security policy rule':
-    ensure => absent;
+  'minimal':
+    ensure => 'absent';
+  'description':
+    ensure => 'absent';
+  'universal':
+    ensure => 'absent';
+  'intrazone':
+    ensure => 'absent';
+  'interzone':
+    ensure => 'absent';
+  'tags':
+    ensure => 'absent';
+  'sources':
+    ensure => 'absent';
+  'destination':
+    ensure => 'absent';
+  'users':
+    ensure => 'absent';
+  'hip-profiles':
+    ensure => 'absent';
+  'applications':
+    ensure => 'absent';
+  'services':
+    ensure => 'absent';
+  'actions':
+    ensure => 'absent';
+  'log-settings':
+    ensure => 'absent';
+  'profile-setting-profiles':
+    ensure => 'absent';
+  'profile-setting-group':
+    ensure => 'absent';
+  'other-settings':
+    ensure =>  'absent';
+  'ip-dscp-settings':
+    ensure =>  'absent';
+  'ip-precedence-settings':
+    ensure =>  'absent';
 }
 
 panos_commit {

--- a/spec/fixtures/update.pp
+++ b/spec/fixtures/update.pp
@@ -148,51 +148,109 @@ panos_nat_policy {
 }
 
 panos_security_policy_rule  {
-  'Default security policy rule':
-    ensure       =>  'present';
-  'Adding a group policy value':
-    ensure       =>  'present',
-    action       =>  'allow',
-    profile_type =>  'group',
-    # group_profile       => 'Custom profile type',
-    log_start    =>  true,
-    qos_type     =>  'ip-dscp',
-    ip_dscp      =>  'af11';
-  'Adding custom profiles':
-    ensure                    =>  'present',
-    profile_type              =>  'profiles',
-    anti_virus_profile        =>  'none',
-    vulnerability_profile     =>  'default',
-    spyware_profile           =>  'default',
-    url_filtering_profile     =>  'default',
-    file_blocking_profile     =>  'none',
-    # data_filtering_profile  =>  'Custom profile type',
-    wildfire_analysis_profile =>  'default';
-  'QoS Marking settings':
-    ensure   =>  'present',
-    qos_type =>  'follow-c2s-flow';
-  'All the options':
-    ensure                             => 'present',
-    rule_type                          => 'interzone',
-    description                        => 'This is managed by Puppet.',
-    # tags         => ['puppet', 'test', 'all', 'options'],
-    # source_zones => ['Custom Zone 1', 'Custom Zone 2'],
-    source_address                     =>  ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
-    # source_users    => ['Custom User', 'Custom User 2'],
-    # hip_profiles      => ['Custom HIP 1', 'Customer HIP 2'],
-    # destination_zones => ['Custom Zone 1', 'Custom Zone 2'],
-    destination_address                =>  ['0.0.0.0-0.255.255.255', '10.0.0.0-10.255.255.255'],
-    applications                       => ['activesync'],
-    services                           => ['service-http'],
-    categories                         => ['games', 'home-and-garden'],
-    action                             => 'reset-client',
-    icmp_unreachable                   => false,
-    # log_setting         => 'custom log settings',
-    # schedule_profile    => 'custom schedule',
-    disable_server_response_inspection =>  false;
-  'Disable a Security Policy Rule':
-    ensure  => 'present',
-    disable =>  true;
+  'minimal':
+    ensure => 'present';
+  'description':
+    ensure      => 'present',
+    description => 'This is still managed by Puppet.';
+  'universal':
+    ensure    => 'present',
+    rule_type => 'intrazone';
+  'intrazone':
+    ensure    => 'present',
+    rule_type => 'universal';
+  'interzone':
+    ensure    => 'present',
+    rule_type => 'universal';
+  'tags':
+    ensure      => 'present',
+    description => 'This is still managed by Puppet.',
+    # tags         =>  ['puppet', 'managed'],
+    rule_type   => 'universal';
+  'sources':
+    ensure         => 'present',
+    description    => 'This is managed by Puppet.',
+    # source_zones => ['custom zone 1', 'custom zone 2'],
+    source_address => ['0.0.0.0-0.255.255.255'],
+    rule_type      => 'universal';
+  'destination':
+    ensure              => 'present',
+    description         => 'This is managed by Puppet.',
+    destination_zones   => ['multicast'],
+    # destination_zones => ['custom zone 3', 'custom zone 4'],
+    source_address      => ['0.0.0.0-0.255.255.255'],
+    destination_address => ['0.0.0.0-0.255.255.255'],
+    rule_type           => 'universal';
+  'users':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    source_users => ['known-user'],
+    # source_users  =>  ['custom user 1', 'customer user 2'],
+    rule_type    => 'universal';
+  'hip-profiles':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    # tags         =>  ['puppet', 'managed'],
+    hip_profiles => ['any'],
+    # hip_profiles  =>  ['custom profile 1', 'custom profile 2'],
+    rule_type    => 'universal';
+  'applications':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    hip_profiles => ['no-hip'],
+    applications => ['1c-enterprise', '1und1-mail'],
+    rule_type    => 'universal';
+  'services':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    services    => ['application-default'],
+    categories  => ['adult', 'content-delivery-networks'],
+    rule_type   => 'universal';
+  'actions':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    action      => 'allow',  
+    rule_type   => 'universal';
+  'log-settings':
+    ensure      => 'present',
+    description => 'This is managed by Puppet.',
+    log_start   => false,
+    log_end     => true;
+    # log_setting   => 'custom log forwarding profile';
+  'profile-setting-profiles':
+    ensure                => 'present',
+    description           => 'This is managed by Puppet.',
+    profile_type          => 'profiles',
+    anti_virus_profile    => 'none',
+    vulnerability_profile => 'none',
+    spyware_profile       => 'none',
+    url_filtering_profile => 'none';
+    # file_blocking_profile => 'custom file blocking profile',
+    # data_filtering_profile  =>  'custom data filtering profile',
+    # wildfire_analysis_profile  =>  'custom analysis profile';
+  'profile-setting-group':
+    ensure       => 'present',
+    description  => 'This is managed by Puppet.',
+    profile_type => 'none';
+    # group_profile => 'custom group profile';
+  'other-settings':
+    ensure                              =>  'present',
+    description                         =>  'This is managed by Puppet.',
+    # schedule_profile  => 'custom schedule profile',
+    qos_type                            => 'none',
+    disable_server_response_inspection  =>  true;
+  'ip-dscp-settings':
+    ensure                              =>  'present',
+    description                         =>  'This is managed by Puppet.',
+    qos_type                            => 'ip-dscp',
+    ip_dscp                             =>  'cs1',
+    disable_server_response_inspection  =>  true;
+  'ip-precedence-settings':
+    ensure                              =>  'present',
+    description                         =>  'This is managed by Puppet.',
+    qos_type                            =>  'ip-precedence',
+    ip_precedence                       =>  'cs1',
+    disable_server_response_inspection  =>  true;
 }
 
 panos_arbitrary_commands  {

--- a/spec/unit/puppet/type/panos_security_policy_rule_spec.rb
+++ b/spec/unit/puppet/type/panos_security_policy_rule_spec.rb
@@ -9,4 +9,32 @@ RSpec.describe 'the panos_security_policy_rule type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_security_policy_rule).context.type.definition).to have_key :base_xpath
   end
+
+  context 'when `name` exceeds 63 characters' do
+    let(:name) { 'longer string exceeding the 63 character limit on a PAN-OS 8.1.2' }
+
+    it 'throws an error' do
+      expect(name.length).to eq 64
+
+      expect {
+        Puppet::Type.type(:panos_security_policy_rule).new(
+          name: name,
+        )
+      }.to raise_error Puppet::ResourceError
+    end
+  end
+
+  context 'when `name` does not exceed 63 characters' do
+    let(:name) { 'the shorter string within a 63 character limit for PAN-OS 8.1.2' }
+
+    it 'does not throw an error' do
+      expect(name.length).to eq 63
+
+      expect {
+        Puppet::Type.type(:panos_security_policy_rule).new(
+          name: name,
+        )
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Updated the `name` pattern to limit to 31 maximum characters along with a unit test to verify.

Improved the `create`, `update` and `delete` manifests to cover more areas.