### PR TITLE
(FM-7299) Compatibility changes for PANOS services provider and type

### DIFF
--- a/lib/puppet/provider/panos_service/panos_service.rb
+++ b/lib/puppet/provider/panos_service/panos_service.rb
@@ -4,18 +4,12 @@ require 'builder'
 
 # Implementation for the panos_service_type type using the Resource API.
 class Puppet::Provider::PanosService::PanosService < Puppet::Provider::PanosProvider
-  def validate_should(should)
-    if should[:src_port].nil? && should[:dest_port].nil? # rubocop:disable Style/GuardClause # line too long
-      raise Puppet::ResourceError, '`src_port` or `dest_port` must be provided'
-    end
-  end
-
   def xml_from_should(name, should)
     builder = Builder::XmlMarkup.new
     builder.entry('name' => name) do
       builder.protocol do
         builder.__send__(should[:protocol]) do
-          builder.port(should[:dest_port]) unless should[:dest_port] == '' || should[:dest_port].nil?
+          builder.port(should[:port])
           builder.__send__('source-port', should[:src_port]) unless should[:src_port] == '' || should[:src_port].nil?
         end
       end

--- a/lib/puppet/type/panos_service.rb
+++ b/lib/puppet/type/panos_service.rb
@@ -9,7 +9,7 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:       'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
+      type:       'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
       desc:       'The display-name of the service.',
       xpath:      'string(@name)',
       behaviour:  :namevar,
@@ -28,15 +28,16 @@ Puppet::ResourceApi.register_type(
       type:      'Enum["tcp", "udp"]',
       desc:      'The network protocol ther service runs on.',
       xpath:     'local-name(protocol/*[1])',
+      default:   'tcp',
     },
-    dest_port: {
-      type:      'Optional[String]',
-      desc:      'If not specified, src_port must be. Port can be a single port number, a range `1-65535`, or comma separated values  `80, 8080, 443`',
+    port: {
+      type:      'String',
+      desc:      'Port can be a single port number, a range `1-65535`, or comma separated values  `80, 8080, 443`',
       xpath:      'protocol/*[1]/port/text()',
     },
     src_port: {
       type:      'Optional[String]',
-      desc:      'If not specified, dest_port must be. Port can be a single port number, a range `1-65535`, or comma separated values  `80, 8080, 443`',
+      desc:      'Port can be a single port number, a range `1-65535`, or comma separated values  `80, 8080, 443`',
       xpath:      'protocol/*[1]/source-port/text()',
     },
     tags: {

--- a/spec/fixtures/create.pp
+++ b/spec/fixtures/create.pp
@@ -55,40 +55,60 @@ panos_admin {
 }
 
 panos_service {
-  # namespace overlap with panos_address: '<![CDATA[ minimal 'minimal' is already in use]]>'
-  'minimal service group':
-    ensure   => 'present',
-    protocol => 'tcp',
-    src_port => '21';
-  'Application':
+  'minimal':
+    ensure    => 'present',
+    port      => '21';
+  'description':
     ensure      => 'present',
-    description => 'Demo App',
-    protocol    => 'tcp',
-    dest_port   => '3478-3479',
-    src_port    => '12345',
-    tags        => [];
-  'Comms':
+    port        => '21',
+    description => 'This is managed by Puppet.';
+  'source port':
     ensure      => 'present',
-    description => 'Voice Chat',
+    port        => '21',
+    src_port    => '23',
+    description => 'This is managed by Puppet.';
+  'udp_description':
+    ensure      => 'present',
+    port        => '21',
     protocol    => 'udp',
-    dest_port   => '8888,8881,8882',
-    src_port    => '1234,3214,5432',
-    tags        => [];
-  'ftp':
+    description => 'This is managed by Puppet.';
+  'udp_source port':
     ensure      => 'present',
-    description => 'ftp server',
-    protocol    => 'tcp',
-    dest_port   => '21',
-    tags        => [];
+    port        => '15',
+    src_port    => '23',
+    protocol    => 'udp',
+    description => 'This is managed by Puppet.';
+  'csv ports':
+    ensure      => 'present',
+    port        => '17, 42, 53',
+    src_port    => '21, 25, 80',
+    description => 'This is managed by Puppet.';
+  'udp_csv ports':
+    ensure      => 'present',
+    port        => '21, 25, 80',
+    src_port    => '21, 24, 82',
+    protocol    => 'udp',
+    description => 'This is managed by Puppet.';
+  'range ports':
+    ensure      => 'present',
+    port        => '21-61',
+    src_port    => '23-82',
+    description => 'This is managed by Puppet.';
+  'udp_range ports':
+    ensure      => 'present',
+    port        => '25-37',
+    src_port    => '20-57',
+    protocol    => 'udp',
+    description => 'This is managed by Puppet.';
 }
 
 panos_service_group {
-  'minimal':
+  'minimal service group':
     ensure   => 'present',
-    services => ['ftp'];
+    services => ['udp_source port'];
   'test group 1':
     ensure   => 'present',
-    services => ['ftp'],
+    services => ['udp_source port'],
     tags     => [],
 }
 

--- a/spec/fixtures/delete.pp
+++ b/spec/fixtures/delete.pp
@@ -36,14 +36,32 @@ panos_admin {
     ensure => absent;
 }
 
-panos_service {
-  'Application':
+panos_service_group {
+  'minimal service group':
+    ensure => absent;
+  'test group 1':
     ensure => absent;
 }
 
-panos_service_group {
-  'test group 1':
-    ensure => absent;
+panos_service {
+  'minimal':
+    ensure  => 'absent';
+  'description':
+    ensure  => 'absent';
+  'source port':
+    ensure  => 'absent';
+  'udp_description':
+    ensure  => 'absent';
+  'udp_source port':
+    ensure  => 'absent';
+  'csv ports':
+    ensure  => 'absent';
+  'udp_csv ports':
+    ensure  => 'absent';
+  'range ports':
+    ensure  => 'absent'; 
+  'udp_range ports':
+    ensure  => 'absent';  
 }
 
 panos_arbitrary_commands {

--- a/spec/fixtures/update.pp
+++ b/spec/fixtures/update.pp
@@ -42,32 +42,58 @@ panos_admin {
 }
 
 panos_service {
-  'Application':
+  'minimal':
+    ensure    => 'present',
+    protocol  => 'udp',
+    port      => '21';
+  'description':
     ensure      => 'present',
-    description => 'Demo App',
-    protocol    => 'tcp',
-    dest_port   => '3478-3480',
-    src_port    => '12345',
-    tags        => [];
-  'Comms':
+    port        => '220',
+    description => 'This is managed by Puppet.';
+  'source port':
     ensure      => 'present',
-    description => 'Voice Chat',
+    port        => '201',
+    src_port    => '259',
+    description => 'This is managed by Puppet.';
+  'udp_description':
+    ensure      => 'present',
+    port        => '220',
     protocol    => 'udp',
-    dest_port   => '8888,8881,8882',
-    src_port    => '1234,3214,5432',
-    tags        => [];
-  'ftp':
+    description => 'This is managed by Puppet.';
+  'udp_source port':
     ensure      => 'present',
-    description => 'ftp server',
-    protocol    => 'tcp',
-    dest_port   => '21',
-    tags        => [];
+    port        => '213',
+    src_port    => '220',
+    protocol    => 'udp',
+    description => 'This is managed by Puppet.';
+  'csv ports':
+    ensure      => 'present',
+    port        => '201, 23, 220',
+    src_port    => '212, 38, 312',
+    description => 'This is managed by Puppet.';
+  'udp_csv ports':
+    ensure      => 'present',
+    port        => '213, 23, 220',
+    src_port    => '56, 38, 47',
+    protocol    => 'udp',
+    description => 'This is managed by Puppet.';
+  'range ports':
+    ensure      => 'present',
+    port        => '212-312',
+    src_port    => '23-50',
+    description => 'This is managed by Puppet.';
+  'udp_range ports':
+    ensure      => 'present',
+    port        => '212-312',
+    src_port    => '17-22',
+    protocol    => 'udp',
+    description => 'This is managed by Puppet.';
 }
 
 panos_service_group {
   'test group 1':
     ensure   => 'present',
-    services => ['ftp', 'Comms'],
+    services => ['udp_range ports', 'csv ports'],
     tags     => [],
 }
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -21,3 +21,35 @@ RSpec.shared_examples 'str_from_xml(xml)' do |test_data, provider|
     end
   end
 end
+
+RSpec.shared_examples '`name` exceeds 63 characters' do |type|
+  context 'when `name` exceeds 63 characters' do
+    let(:name) { 'longer string exceeding the 63 character limit on a PAN-OS 8.1.0' }
+
+    it 'throws an error' do
+      expect(name.length).to eq 64
+
+      expect {
+        Puppet::Type.type(type).new(
+          name: name,
+        )
+      }.to raise_error Puppet::ResourceError
+    end
+  end
+end
+
+RSpec.shared_examples '`name` does not exceed 63 characters' do |type|
+  context 'when `name` does not exceed 63 characters' do
+    let(:name) { 'the shorter string within a 63 character limit for PAN-OS 8.1.0' }
+
+    it 'does not throw an error' do
+      expect(name.length).to eq 63
+
+      expect {
+        Puppet::Type.type(type).new(
+          name: name,
+        )
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/puppet/provider/panos_service/panos_service_spec.rb
+++ b/spec/unit/puppet/provider/panos_service/panos_service_spec.rb
@@ -7,65 +7,6 @@ require 'puppet/provider/panos_service/panos_service'
 RSpec.describe Puppet::Provider::PanosService::PanosService do
   subject(:provider) { described_class.new }
 
-  describe 'validate_should(should)' do
-    context 'when src_port port is provided' do
-      let(:should_hash) do
-        {
-          name: 'service1',
-          ensure: 'present',
-          description: 'example service',
-          protocol: 'tcp',
-          src_port: '2222',
-          tags: ['tag1', 'tag2'],
-        }
-      end
-
-      it { expect { provider.validate_should(should_hash) }.not_to raise_error }
-    end
-    context 'when is dest_port port is provided' do
-      let(:should_hash) do
-        {
-          name: 'service1',
-          ensure: 'present',
-          description: 'example service',
-          protocol: 'tcp',
-          dest_port: '8888,8881,8882',
-          tags: ['tag1', 'tag2'],
-        }
-      end
-
-      it { expect { provider.validate_should(should_hash) }.not_to raise_error }
-    end
-    context 'when is dest_port and src_port port is provided' do
-      let(:should_hash) do
-        {
-          name: 'service1',
-          ensure: 'present',
-          description: 'example service',
-          protocol: 'tcp',
-          dest_port: '8888,8881,8882',
-          src_port: '2222',
-          tags: ['tag1', 'tag2'],
-        }
-      end
-
-      it { expect { provider.validate_should(should_hash) }.not_to raise_error }
-    end
-    context 'when neither src_port or dest_port port is provided' do
-      let(:should_hash) do
-        {
-          name: 'service1',
-          ensure: 'present',
-          description: 'example service',
-          protocol: 'tcp',
-          tags: ['tag1', 'tag2'],
-        }
-      end
-
-      it { expect { provider.validate_should(should_hash) }.to raise_error Puppet::ResourceError, %r{`src_port` or `dest_port` must be provided} }
-    end
-  end
-
   test_data = [
     {
       desc: 'a UDP example with destination and source ports specified',
@@ -74,7 +15,7 @@ RSpec.describe Puppet::Provider::PanosService::PanosService do
         ensure:       'present',
         description:  'abc',
         protocol:     'udp',
-        dest_port:    '8888,8881,8882',
+        port:         '8888,8881,8882',
         src_port:     '1234,3214,5432',
         tags:         ['foo'],
       },
@@ -98,7 +39,7 @@ RSpec.describe Puppet::Provider::PanosService::PanosService do
         ensure:       'present',
         description:  'abc',
         protocol:     'tcp',
-        dest_port:    '8888,8881,8882',
+        port:         '8888,8881,8882',
         src_port:     '1234,3214,5432',
         tags:         ['foo'],
       },
@@ -118,40 +59,17 @@ RSpec.describe Puppet::Provider::PanosService::PanosService do
     {
       desc: 'a TCP example with only a destintaion port specified',
       attrs: {
-        name:         'dest_port_only',
+        name:         'port_only',
         ensure:       'present',
         description:  'abc',
         protocol:     'tcp',
-        dest_port:    '21',
+        port:         '21',
         tags:         ['foo', 'bar'],
       },
-      xml: '<entry name="dest_port_only">
+      xml: '<entry name="port_only">
               <protocol>
                 <tcp>
                   <port>21</port>
-                </tcp>
-              </protocol>
-              <description>abc</description>
-              <tag>
-                <member>foo</member>
-                <member>bar</member>
-              </tag>
-            </entry>',
-    },
-    {
-      desc: 'a TCP example with only a source port specified',
-      attrs: {
-        name:         'src_port_only',
-        ensure:       'present',
-        description:  'abc',
-        protocol:     'tcp',
-        src_port:     '21',
-        tags:         ['foo', 'bar'],
-      },
-      xml: '<entry name="src_port_only">
-              <protocol>
-                <tcp>
-                  <source-port>21</source-port>
                 </tcp>
               </protocol>
               <description>abc</description>
@@ -168,12 +86,12 @@ RSpec.describe Puppet::Provider::PanosService::PanosService do
         ensure:       'present',
         description:  'abc',
         protocol:     'tcp',
-        src_port:     '21',
+        port:         '21',
       },
       xml: '<entry name="no_tags">
               <protocol>
                 <tcp>
-                  <source-port>21</source-port>
+                  <port>21</port>
                 </tcp>
               </protocol>
               <description>abc</description>

--- a/spec/unit/puppet/type/panos_security_policy_rule_spec.rb
+++ b/spec/unit/puppet/type/panos_security_policy_rule_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/shared_examples'
 require 'puppet/type/panos_security_policy_rule'
 
 RSpec.describe 'the panos_security_policy_rule type' do
@@ -10,31 +11,7 @@ RSpec.describe 'the panos_security_policy_rule type' do
     expect(Puppet::Type.type(:panos_security_policy_rule).context.type.definition).to have_key :base_xpath
   end
 
-  context 'when `name` exceeds 63 characters' do
-    let(:name) { 'longer string exceeding the 63 character limit on a PAN-OS 8.1.0' }
+  include_examples '`name` exceeds 63 characters', :panos_security_policy_rule
 
-    it 'throws an error' do
-      expect(name.length).to eq 64
-
-      expect {
-        Puppet::Type.type(:panos_security_policy_rule).new(
-          name: name,
-        )
-      }.to raise_error Puppet::ResourceError
-    end
-  end
-
-  context 'when `name` does not exceed 63 characters' do
-    let(:name) { 'the shorter string within a 63 character limit for PAN-OS 8.1.0' }
-
-    it 'does not throw an error' do
-      expect(name.length).to eq 63
-
-      expect {
-        Puppet::Type.type(:panos_security_policy_rule).new(
-          name: name,
-        )
-      }.not_to raise_error
-    end
-  end
+  include_examples '`name` does not exceed 63 characters', :panos_security_policy_rule
 end

--- a/spec/unit/puppet/type/panos_service_spec.rb
+++ b/spec/unit/puppet/type/panos_service_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'puppet/type/panos_service'
+require 'support/shared_examples'
 
 RSpec.describe 'the panos_service type' do
   it 'loads' do
@@ -9,4 +10,8 @@ RSpec.describe 'the panos_service type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_service).context.type.definition).to have_key :base_xpath
   end
+
+  include_examples '`name` exceeds 63 characters', :panos_service
+
+  include_examples '`name` does not exceed 63 characters', :panos_service
 end


### PR DESCRIPTION
Includes a shared example for testing the maximum character limit on the `name` value, updated existing tests to make use of this shared example.

Removal of `validate_should` as no longer needed as `port` is a required field anyway, so removed the `Optional` type from `port`.