### PR TITLE
(FM-7294) Compatibility changes for PANOS address type and provider

### DIFF
--- a/spec/fixtures/create.pp
+++ b/spec/fixtures/create.pp
@@ -2,7 +2,8 @@
 
 panos_address {
   'minimal':
-    ensure => 'present';
+    ensure      => 'present',
+    ip_range    => '192.168.0.1-192.168.0.17';
   'address-3':
     ip_range    => '192.168.0.1-192.168.0.17',
     description => '<eas&lt;yxss/>';
@@ -18,6 +19,8 @@ panos_address {
     ip_netmask => '10.30.1.0';
   'DAT_address':
     ip_netmask => '10.30.1.1';
+  'fqdn':
+    fqdn => 'google-public-dns-a.google.com';
 }
 
 panos_address_group {

--- a/spec/fixtures/delete.pp
+++ b/spec/fixtures/delete.pp
@@ -1,7 +1,23 @@
 # bundle exec puppet device --modulepath spec/fixtures/modules/ --deviceconfig spec/fixtures/device.conf --target pavm --verbose --trace --apply tests/test_commit.pp
 
 panos_address {
+  'minimal':
+    ensure => absent;
+  'address-3':
+    ensure => absent;
   'source_address':
+    ensure => absent;
+  'SAT_address':
+    ensure => absent;
+  'SAT_static_address':
+    ensure => absent;
+  'fallback_address':
+    ensure => absent;
+  'destination_address':
+    ensure => absent;
+  'DAT_address':
+    ensure => absent;
+  'fqdn':
     ensure => absent;
 }
 

--- a/spec/fixtures/update.pp
+++ b/spec/fixtures/update.pp
@@ -16,6 +16,8 @@ panos_address {
     ip_netmask => '10.30.1.0';
   'DAT_address':
     ip_netmask => '10.30.1.1';
+  'fqdn':
+    fqdn  =>  'google-public-dns-b.google.com';
 }
 
 panos_address_group {


### PR DESCRIPTION
Fixed up the acceptance testing in `create.pp` as the `minimal` entry was failing, also added an `fqdn` example.

`delete.pp` sets all entries to absent to allow subsequent runs of the acceptance test locally.