### PR TITLE
(FM-7295) Compatibility changes for PANOS address_group provider and …

### DIFF
--- a/lib/puppet/type/panos_address_group.rb
+++ b/lib/puppet/type/panos_address_group.rb
@@ -30,9 +30,9 @@ Puppet::ResourceApi.register_type(
       xpath:     'local-name(static|dynamic)',
     },
     static_members: {
-      type:      'Optional[Array[String]]',
-      desc:      'An array of `panos_address`, or `panos_address_group` that form this group. Used only when type is static.',
-      xpath_array:     'static/member/text()',
+      type:         'Optional[Array[String]]',
+      desc:         'An array of `panos_address`, or `panos_address_group` that form this group. Used only when type is static.',
+      xpath_array:  'static/member/text()',
     },
     dynamic_filter: {
       type:      'Optional[String]',
@@ -45,10 +45,10 @@ DESC
       xpath:      'dynamic/filter/text()',
     },
     tags: {
-      type:      'Array[String]',
-      desc:      'The Palo Alto tags to apply to this address-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
-      default:   [],
-      xpath_array:     'tag/member/text()',
+      type:         'Array[String]',
+      desc:         'The Palo Alto tags to apply to this address-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
+      default:      [],
+      xpath_array:  'tag/member/text()',
     },
   },
   autobefore: {

--- a/spec/fixtures/delete.pp
+++ b/spec/fixtures/delete.pp
@@ -1,5 +1,15 @@
 # bundle exec puppet device --modulepath spec/fixtures/modules/ --deviceconfig spec/fixtures/device.conf --target pavm --verbose --trace --apply tests/test_commit.pp
 
+panos_address_group {
+  'full':
+    ensure  =>  absent;
+  # namespace overlap with panos_address: '<![CDATA[ address-group -> minimal 'minimal' is already in use]]>'
+  'minimal address group':
+    ensure  =>  absent;
+  'dynamic group':
+    ensure  =>  absent;
+}
+
 panos_address {
   'minimal':
     ensure => absent;
@@ -18,11 +28,6 @@ panos_address {
   'DAT_address':
     ensure => absent;
   'fqdn':
-    ensure => absent;
-}
-
-panos_address_group {
-  'full':
     ensure => absent;
 }
 

--- a/spec/fixtures/update.pp
+++ b/spec/fixtures/update.pp
@@ -22,14 +22,14 @@ panos_address {
 
 panos_address_group {
   'full':
-    description    => 'address group with static contents',
+    description    => 'address group with static contents, and an existing address group',
     type           => 'static',
-    static_members => ['source_address'];
+    static_members => ['source_address', 'minimal address group'];
     # tags           => ['tests'];
-  'empty':
+  'dynamic group':
     description    => 'address group with dynamic contents',
     type           => 'dynamic',
-    dynamic_filter => "'tag1' or 'tag2'";
+    dynamic_filter => "'tag1' or 'tag2' and 'tag3'";
     # tags           => ['tests'],
 }
 


### PR DESCRIPTION
…type

Reordering the `delete.pp` so that the acceptance tests can run correctly as it needs to execute before the `panos_address`.

General fixes to the indentation of the type to make it consistent with the rest.