### PR TITLE
(maint) Additional validation in PANOS address to raise error if no t…

### DIFF
--- a/lib/puppet/provider/panos_address/panos_address.rb
+++ b/lib/puppet/provider/panos_address/panos_address.rb
@@ -5,8 +5,11 @@ require 'builder'
 # Implementation for the panos_address type using the Resource API.
 class Puppet::Provider::PanosAddress::PanosAddress < Puppet::Provider::PanosProvider
   def validate_should(should)
-    if [should[:ip_netmask], should[:ip_range], should[:fqdn]].compact.size > 1 # rubocop:disable Style/GuardClause # line too long
+    required = [should[:ip_netmask], should[:ip_range], should[:fqdn]].compact.size
+    if required > 1 # rubocop:disable Style/GuardClause
       raise Puppet::ResourceError, 'ip_netmask, ip_range, and fqdn are mutually exclusive fields'
+    elsif required.zero?
+      raise Puppet::ResourceError, 'One of the following attributes must be provided: ip_netmask, ip_range, or fqdn'
     end
   end
 

--- a/spec/unit/puppet/provider/panos_address/panos_address_spec.rb
+++ b/spec/unit/puppet/provider/panos_address/panos_address_spec.rb
@@ -89,6 +89,18 @@ RSpec.describe Puppet::Provider::PanosAddress::PanosAddress do
 
       it { expect { provider.validate_should(should_hash) }.to raise_error Puppet::ResourceError, %r{ip_netmask, ip_range, and fqdn are mutually exclusive fields} }
     end
+    context 'when ip_range, ip_netmask, or fqdn is not provided' do
+      let(:should_hash) do
+        {
+          name: 'address-2',
+          ensure: 'present',
+          description: 'some address',
+          tags: ['a'],
+        }
+      end
+
+      it { expect { provider.validate_should(should_hash) }.to raise_error Puppet::ResourceError, %r{One of the following attributes must be provided: ip_netmask, ip_range, or fqdn} }
+    end
   end
 
   test_data = [


### PR DESCRIPTION
…ype supplied

PANOS address requires one of the following types to be supplied `ip_netmask`, `ip_range`, and `fqdn`