### PR TITLE
(FM-7300) Compatibility changes for service group provider and …

### DIFF
--- a/lib/puppet/type/panos_service_group.rb
+++ b/lib/puppet/type/panos_service_group.rb
@@ -9,7 +9,7 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
+      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
       desc:      'The display-name of the service-group.',
       behaviour: :namevar,
       xpath:      'string(@name)',
@@ -20,15 +20,15 @@ Puppet::ResourceApi.register_type(
       default: 'present',
     },
     services: {
-      type:      'Array[String]',
-      desc:      'An array of `panos_service`, or `panos_service_group` that form this group.',
-      xpath_array:     'members/member/text()',
+      type:         'Array[String]',
+      desc:         'An array of `panos_service`, or `panos_service_group` that form this group.',
+      xpath_array:  'members/member/text()',
     },
     tags: {
-      type:      'Array[String]',
-      desc:      'The Palo Alto tags to apply to this service-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
-      default:   [],
-      xpath_array:     'tag/member/text()',
+      type:         'Array[String]',
+      desc:         'The Palo Alto tags to apply to this service-group. Do not confuse this with the `tag` metaparameter used to filter resource application.',
+      default:      [],
+      xpath_array:  'tag/member/text()',
     },
   },
   autobefore: {

--- a/spec/fixtures/delete.pp
+++ b/spec/fixtures/delete.pp
@@ -37,9 +37,9 @@ panos_admin {
 }
 
 panos_service_group {
-  'minimal service group':
-    ensure => absent;
   'test group 1':
+    ensure => absent;
+  'minimal service group':
     ensure => absent;
 }
 

--- a/spec/fixtures/update.pp
+++ b/spec/fixtures/update.pp
@@ -91,10 +91,13 @@ panos_service {
 }
 
 panos_service_group {
+  'minimal service group':
+    ensure   => 'present',
+    services => ['source port'];
   'test group 1':
     ensure   => 'present',
-    services => ['udp_range ports', 'csv ports'],
-    tags     => [],
+    services => ['udp_range ports', 'csv ports', 'minimal service group'],
+    tags     => [];
 }
 
 panos_arbitrary_commands {

--- a/spec/unit/puppet/type/panos_service_group_spec.rb
+++ b/spec/unit/puppet/type/panos_service_group_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/shared_examples'
 require 'puppet/type/panos_service_group'
 
 RSpec.describe 'the panos_service_group type' do
@@ -9,4 +10,8 @@ RSpec.describe 'the panos_service_group type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_service_group).context.type.definition).to have_key :base_xpath
   end
+
+  include_examples '`name` exceeds 63 characters', :panos_service_group
+
+  include_examples '`name` does not exceed 63 characters', :panos_service_group
 end


### PR DESCRIPTION
…type

Adding in the 63 character limit for the pattern on the `name` field to match PAN-OS validation on both 7.1.0 and 8.1.0.

Added in a `service_group` in the `update.pp` and reordered the entries in `delete.pp` to match this sequence of events.