### PR TITLE
(FM-7280) Creation of panos::install class for dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,5 @@
 ---
 fixtures:
   forge_modules:
+    resource_api: 'puppetlabs/resource_api'
+    puppetserver_gem: "puppetlabs/puppetserver_gem"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ This module provides a Puppet task to manually `commit`, `store_config` to a fil
 
 ### Setup Requirements
 
-This module requires a user that can access the device's web management interface.
+This module requires a user that can access the device's web management interface and the dependences will need to be installed.
+
+The PANOS module has a dependency on the `resource_api`, the setup instructions can be found [on the Resource API README](https://github.com/puppetlabs/puppetlabs-resource_api#resource_api).
+
+* on each puppetserver or PE master that needs to manage PANOS devices, classify or apply the `panos::server` class.
+* on each puppet agent that needs to manage PAOS devices, classify or apply the `panos::agent` class.
 
 ### Beginning with PANOS
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3,6 +3,11 @@
 
 ## Table of Contents
 
+**Classes**
+
+* [`panos::agent`](#panosagent): This resource will manage the resource_api::agent and the builder gem on an agent
+* [`panos::server`](#panosserver): This resource manages the resource_api::server on the server
+
 **Resource types**
 
 * [`panos_address`](#panos_address): This type provides Puppet with the capabilities to manage "address" objects on Palo Alto devices.
@@ -22,6 +27,32 @@
 * [`apikey`](#apikey): Retrieve a PAN-OS apikey using PAN-OS host, username and password.
 * [`commit`](#commit): Commit a candidate configuration to a firewall.
 * [`config`](#config): upload and/or apply a configuration to a firewall.
+
+## Classes
+
+### panos::agent
+
+This resource will manage the resource_api::agent and the builder gem on an agent
+
+#### Examples
+
+##### 
+
+```puppet
+include panos::agent
+```
+
+### panos::server
+
+This resource manages the resource_api::server on the server
+
+#### Examples
+
+##### 
+
+```puppet
+include panos::server
+```
 
 ## Resource types
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,0 +1,12 @@
+# @summary
+#   This resource will manage the resource_api::agent and the builder gem on an agent
+#
+# @example
+#   include panos::agent
+class panos::agent {
+  include resource_api::agent
+  package { 'builder':
+    ensure   => present,
+    provider => 'puppet_gem',
+  }
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,0 +1,8 @@
+# @summary
+#   This resource manages the resource_api::server on the server
+#
+# @example
+#   include panos::server
+class panos::server {
+  include resource_api::server
+}

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'panos::agent' do
+  test_on = {
+    hardwaremodels: ['x86_64', 'i686'],
+    supported_os: [
+      {
+        'operatingsystem'        => 'RedHat',
+        'operatingsystemrelease' => ['7'],
+      },
+      {
+        'operatingsystem'        => 'Ubuntu',
+        'operatingsystemrelease' => ['16.04'],
+      },
+      {
+        'operatingsystem'        => 'OracleLinux',
+        'operatingsystemrelease' => ['7'],
+      },
+      {
+        'operatingsystem'        => 'windows',
+      },
+    ],
+  }
+
+  on_supported_os(test_on).each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_package('Resource API on the puppet AIO') }
+      it { is_expected.to contain_package('builder') }
+    end
+  end
+end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'panos::server' do
+  test_on = {
+    supported_os: [
+      {
+        'operatingsystem'        => 'RedHat',
+        'operatingsystemrelease' => ['7'],
+      },
+      {
+        'operatingsystem'        => 'Ubuntu',
+        'operatingsystemrelease' => ['16.04'],
+      },
+      {
+        'operatingsystem'        => 'OracleLinux',
+        'operatingsystemrelease' => ['7'],
+      },
+    ],
+  }
+
+  on_supported_os(test_on).each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:pre_cond) { 'service { "puppetserver": }' }
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_package('Resource API on the puppetserver') }
+    end
+  end
+end


### PR DESCRIPTION
Ensures that the builder gem is present on agent and the resource_api::agent is included.