### PR TITLE
(maint) update pattern matches on PANOS types name attributes

### DIFF
--- a/lib/puppet/type/panos_address.rb
+++ b/lib/puppet/type/panos_address.rb
@@ -9,7 +9,7 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
+      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
       desc:      'The display-name of the address.',
       behaviour: :namevar,
       xpath:      'string(@name)',

--- a/lib/puppet/type/panos_address_group.rb
+++ b/lib/puppet/type/panos_address_group.rb
@@ -9,7 +9,7 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]*$/]',
+      type:      'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
       desc:      'The display-name of the address-group.',
       behaviour: :namevar,
       xpath:      'string(@name)',

--- a/lib/puppet/type/panos_nat_policy.rb
+++ b/lib/puppet/type/panos_nat_policy.rb
@@ -9,8 +9,8 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:       'String',
-      desc:       'The display-name of the zone.',
+      type:       'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
+      desc:       'The display-name of the zone. Restricted to 31 characters on PAN-OS version 7.1.0.',
       xpath:      'string(@name)',
       behaviour:  :namevar,
     },

--- a/lib/puppet/type/panos_security_policy_rule.rb
+++ b/lib/puppet/type/panos_security_policy_rule.rb
@@ -10,7 +10,7 @@ Puppet::ResourceApi.register_type(
   attributes: {
     name: {
       type:      'Pattern[/^[a-zA-z0-9\-_\s\.]{1,63}$/]',
-      desc:      'The display-name of the security-policy-rule. Restricted to 31 characters on PAN-OS version < 8.1.0.',
+      desc:      'The display-name of the security-policy-rule. Restricted to 31 characters on PAN-OS version 7.1.0.',
       behaviour: :namevar,
       xpath:     'string(@name)',
     },

--- a/lib/puppet/type/panos_tag.rb
+++ b/lib/puppet/type/panos_tag.rb
@@ -9,7 +9,7 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:       'String',
+      type:       'Pattern[/^[a-zA-z0-9\-_\s\.]{1,127}$/]',
       desc:       'The display-name of the tag.',
       xpath:      'string(@name)',
       behaviour:  :namevar,

--- a/lib/puppet/type/panos_zone.rb
+++ b/lib/puppet/type/panos_zone.rb
@@ -9,7 +9,7 @@ Puppet::ResourceApi.register_type(
   features: ['remote_resource'],
   attributes: {
     name: {
-      type:            'String',
+      type:            'Pattern[/^[a-zA-z0-9\-\s_\.]{1,31}$/]',
       desc:            'The display-name of the zone.',
       xpath:           'string(@name)',
       behaviour:       :namevar,

--- a/spec/unit/puppet/type/panos_address_group_spec.rb
+++ b/spec/unit/puppet/type/panos_address_group_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/shared_examples'
 require 'puppet/type/panos_address_group'
 
 RSpec.describe 'the panos_address_group type' do
@@ -9,4 +10,8 @@ RSpec.describe 'the panos_address_group type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_address_group).context.type.definition).to have_key :base_xpath
   end
+
+  include_examples '`name` exceeds 63 characters', :panos_address_group
+
+  include_examples '`name` does not exceed 63 characters', :panos_address_group
 end

--- a/spec/unit/puppet/type/panos_address_spec.rb
+++ b/spec/unit/puppet/type/panos_address_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'support/shared_examples'
 require 'puppet/type/panos_address'
 
 RSpec.describe 'the panos_address type' do
@@ -9,4 +10,8 @@ RSpec.describe 'the panos_address type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_address).context.type.definition).to have_key :base_xpath
   end
+
+  include_examples '`name` exceeds 63 characters', :panos_address
+
+  include_examples '`name` does not exceed 63 characters', :panos_address
 end

--- a/spec/unit/puppet/type/panos_nat_policy_spec.rb
+++ b/spec/unit/puppet/type/panos_nat_policy_spec.rb
@@ -1,8 +1,13 @@
 require 'spec_helper'
+require 'support/shared_examples'
 require 'puppet/type/panos_nat_policy'
 
 RSpec.describe 'the panos_nat_policy type' do
   it 'loads' do
     expect(Puppet::Type.type(:panos_nat_policy)).not_to be_nil
   end
+
+  include_examples '`name` exceeds 63 characters', :panos_nat_policy
+
+  include_examples '`name` does not exceed 63 characters', :panos_nat_policy
 end

--- a/spec/unit/puppet/type/panos_tag_spec.rb
+++ b/spec/unit/puppet/type/panos_tag_spec.rb
@@ -9,4 +9,32 @@ RSpec.describe 'the panos_tag type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_tag).context.type.definition).to have_key :base_xpath
   end
+
+  context 'when `name` exceeds 127 characters' do
+    let(:name) { 'longer string exceeding the 127 character limit on a PAN-OS 8.1.0 for PANOS tag entries as they are restricted to 127 characters' }
+
+    it 'throws an error' do
+      expect(name.length).to eq 128
+
+      expect {
+        Puppet::Type.type(:panos_tag).new(
+          name: name,
+        )
+      }.to raise_error Puppet::ResourceError
+    end
+  end
+
+  context 'when `name` does not exceed 31 characters' do
+    let(:name) { 'shorter string within the 127 character limit set on a PAN-OS 8.1.0 for PANOS tag entries as it is restricted to 127 characters' }
+
+    it 'does not throw an error' do
+      expect(name.length).to eq 127
+
+      expect {
+        Puppet::Type.type(:panos_tag).new(
+          name: name,
+        )
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/unit/puppet/type/panos_zone_spec.rb
+++ b/spec/unit/puppet/type/panos_zone_spec.rb
@@ -9,4 +9,32 @@ RSpec.describe 'the panos_zone type' do
   it 'has a base_xpath' do
     expect(Puppet::Type.type(:panos_zone).context.type.definition).to have_key :base_xpath
   end
+
+  context 'when `name` exceeds 31 characters' do
+    let(:name) { 'this is longer than 31 character' }
+
+    it 'throws an error' do
+      expect(name.length).to eq 32
+
+      expect {
+        Puppet::Type.type(:panos_zone).new(
+          name: name,
+        )
+      }.to raise_error Puppet::ResourceError
+    end
+  end
+
+  context 'when `name` does not exceed 31 characters' do
+    let(:name) { 'the exactly 31 character string' }
+
+    it 'does not throw an error' do
+      expect(name.length).to eq 31
+
+      expect {
+        Puppet::Type.type(:panos_zone).new(
+          name: name,
+        )
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
For consistency across the types the correct pattern has been added to
ensure the correct validation is applied for the various types.