### PR TITLE
(maint) static route update method now uses set_config

### DIFF
--- a/lib/puppet/provider/panos_static_route_base.rb
+++ b/lib/puppet/provider/panos_static_route_base.rb
@@ -102,10 +102,10 @@ class Puppet::Provider::PanosStaticRouteBase < Puppet::Provider::PanosProvider
     context.device.set_config(context.type.definition[:base_xpath], xml_from_should(should[:name], should))
   end
 
-  def update(context, name, should)
+  def update(context, _name, should)
     context.type.definition[:base_xpath] = "/config/devices/entry/network/virtual-router/entry[@name='#{should[:vr_name]}']/routing-table/#{@version_label}/static-route"
     validate_should(should)
-    context.device.edit_config(context.type.definition[:base_xpath] + "/entry[@name='#{name}']", xml_from_should(should[:name], should))
+    context.device.set_config(context.type.definition[:base_xpath], xml_from_should(should[:name], should))
   end
 
   def delete(context, name, vr_name)

--- a/spec/unit/puppet/provider/panos_static_route_base_spec.rb
+++ b/spec/unit/puppet/provider/panos_static_route_base_spec.rb
@@ -536,7 +536,7 @@ EOF
   describe '#update(context, name, should)' do
     context 'when called' do
       let(:expected_path) do
-        '/config/devices/entry/network/virtual-router/entry[@name=\'bar\']/routing-table/ip/static-route/entry[@name=\'name\']'
+        '/config/devices/entry/network/virtual-router/entry[@name=\'bar\']/routing-table/ip/static-route'
       end
       let(:should_values) do
         {
@@ -550,7 +550,7 @@ EOF
         expect(typedef).to receive(:definition).and_return(mystruct).twice
         expect(provider).to receive(:validate_should).with(should_values)
         expect(provider).to receive(:xml_from_should).with('foo', should_values)
-        expect(device).to receive(:edit_config).with(expected_path, anything)
+        expect(device).to receive(:set_config).with(expected_path, anything)
         provider.update(context, 'name', should_values)
       end
     end


### PR DESCRIPTION
Trying to directly edit a static route config would cause PANOS validation errors, by setting the config changes it resolves these issues.