### PR TITLE
(FM-7400) consistency of credentials files without device modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,19 @@ There are two valid types of credential files:
 
 * (a) A file containing the host, username and password in plain text, for example:
   ```
-  host: 10.0.10.20
-  user: admin
+  address: 10.0.10.20
+  username: admin
   password: admin
   ```
-* (b) A file containing the host and an API key obtained from the device, for example:
+* (b) A file containing the address and an API key obtained from the device, for example:
   ```
-  host: 10.0.10.20
+  address: 10.0.10.20
   apikey: LUFRPT10cHhRNXMyR2wrYW1MSzg5cldhNElodmVkL1U9OEV1cGY5ZjJyc2xGL1Z4Qk9TNFM2dz09
   ```
+
+__Note:__ v0.1.0 requires `host` instead of `address`
+
+__Note:__ v0.1.0 requires `user` instead of `username`
 
 To obtain an API key for the device, it is possible to use the `panos::apikey` task. The required creditials file should be in the format of (a) above. After which you can discard it. Before running this task, install the module on your machine, along with [Puppet Bolt](https://puppet.com/docs/bolt/0.x/bolt_installing.html). When complete, execute the following command:
 

--- a/lib/puppet/util/network_device/panos/device.rb
+++ b/lib/puppet/util/network_device/panos/device.rb
@@ -13,9 +13,11 @@ module Puppet::Util::NetworkDevice::Panos
     end
 
     def config
-      raise Puppet::ResourceError, 'Could not find host in the configuration' unless super.key?('host')
+      raise Puppet::ResourceError, 'Could not find host or address in the configuration' unless super.key?('host') || super.key?('address')
       raise Puppet::ResourceError, 'The port attribute in the configuration is not an integer' if super.key?('port') && super['port'] !~ %r{\A[0-9]+\Z}
-      raise Puppet::ResourceError, 'Could not find user/password or apikey in the configuration' unless (super.key?('user') && super.key?('password')) || super.key?('apikey')
+      raise Puppet::ResourceError, 'Could not find user/password or apikey in the configuration' unless ((super.key?('user') || super.key?('username')) && super.key?('password')) || super.key?('apikey') # rubocop:disable Metrics/LineLength
+      raise Puppet::ResourceError, 'User and username are mutually exclusive' if super.key?('user') && super.key?('username')
+      raise Puppet::ResourceError, 'Host and address are mutually exclusive' if super.key?('host') && super.key?('address')
       super
     end
 
@@ -112,9 +114,9 @@ module Puppet::Util::NetworkDevice::Panos
   # @api private
   class API
     def initialize(credentials)
-      @host = credentials['host']
+      @host = credentials['host'] || credentials['address']
       @port = credentials.key?('port') ? credentials['port'].to_i : 443
-      @user = credentials['user']
+      @user = credentials['user'] || credentials['username']
       @password = credentials['password']
       @apikey = credentials['apikey']
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -47,8 +47,8 @@ RSpec.configure do |c|
 
     File.open('spec/fixtures/acceptance-credentials.conf', 'w') do |file|
       file.puts <<CREDENTIALS
-host: #{@hostname}
-user: #{ENV['PANOS_TEST_USER'] || 'admin'}
+address: #{@hostname}
+username: #{ENV['PANOS_TEST_USER'] || 'admin'}
 password: #{ENV['PANOS_TEST_PASSWORD'] || 'admin'}
 CREDENTIALS
     end

--- a/spec/unit/puppet/util/network_device/panos/device_spec.rb
+++ b/spec/unit/puppet/util/network_device/panos/device_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Puppet::Util::NetworkDevice::Panos do
         context 'when host is not provided' do
           let(:device_config) { { 'user' => 'admin', 'password' => 'password' } }
 
-          it { expect { device.config }.to raise_error Puppet::ResourceError, 'Could not find host in the configuration' }
+          it { expect { device.config }.to raise_error Puppet::ResourceError, 'Could not find host or address in the configuration' }
         end
         context 'when port is provided but not valid' do
           let(:device_config) { { 'host' => 'www.example.com', 'port' => 'foo', 'user' => 'admin', 'password' => 'password' } }
@@ -58,6 +58,7 @@ RSpec.describe Puppet::Util::NetworkDevice::Panos do
           [
             { 'host' => 'www.example.com', 'user' => 'admin' },
             { 'host' => 'www.example.com', 'password' => 'password' },
+            { 'host' => 'www.example.com', 'username' => 'admin' },
             { 'host' => 'www.example.com' },
           ].each do |config|
             let(:device_config) { config }
@@ -70,10 +71,30 @@ RSpec.describe Puppet::Util::NetworkDevice::Panos do
 
           it { expect { device.config }.not_to raise_error Puppet::ResourceError }
         end
-        context 'when username and password is provided' do
+        context 'when `user` and password is provided' do
           let(:device_config) { { 'host' => 'www.example.com', 'user' => 'foo', 'password' => 'password' } }
 
           it { expect { device.config }.not_to raise_error Puppet::ResourceError }
+        end
+        context 'when `username` and password is provided' do
+          let(:device_config) { { 'host' => 'www.example.com', 'username' => 'foo', 'password' => 'password' } }
+
+          it { expect { device.config }.not_to raise_error Puppet::ResourceError }
+        end
+        context 'when `host` and `address` and password is provided' do
+          let(:device_config) { { 'host' => 'www.example.com', 'address' => 'www.example.com', 'username' => 'foo', 'password' => 'password' } }
+
+          it { expect { device.config }.to raise_error Puppet::ResourceError, 'Host and address are mutually exclusive' }
+        end
+        context 'when `address` is provided' do
+          let(:device_config) { { 'address' => 'www.example.com', 'username' => 'foo', 'password' => 'password' } }
+
+          it { expect { device.config }.not_to raise_error }
+        end
+        context 'when `user` and `username` and password is provided' do
+          let(:device_config) { { 'host' => 'www.example.com', 'user' => 'foo', 'username' => 'foo', 'password' => 'password' } }
+
+          it { expect { device.config }.to raise_error Puppet::ResourceError, 'User and username are mutually exclusive' }
         end
       end
 


### PR DESCRIPTION
Other network device modules refer to the user as a `username` and a `host` as `address`, this PR makes it possible to use either `host` or `address` and `user` or `username` in the credentials files to make it similar to other device modules.