### PR TITLE
(PDK-1143) changes to work with composite namevars from simple provider

### DIFF
--- a/lib/puppet/provider/panos_path_monitor_base.rb
+++ b/lib/puppet/provider/panos_path_monitor_base.rb
@@ -14,9 +14,9 @@ class Puppet::Provider::PanosPathMonitorBase < Puppet::Provider::PanosProvider
     entry
   end
 
-  def xml_from_should(_name, should)
+  def xml_from_should(name, should)
     builder = Builder::XmlMarkup.new
-    builder.entry('name' => should[:path]) do
+    builder.entry('name' => name[:path]) do
       builder.source(should[:source])
       builder.destination(should[:destination])
       builder.interval(should[:interval])
@@ -49,20 +49,20 @@ class Puppet::Provider::PanosPathMonitorBase < Puppet::Provider::PanosProvider
     results
   end
 
-  def create(context, _name, should)
-    paths = should[:route].split('/')
+  def create(context, name, should)
+    paths = name[:route].split('/')
     context.type.definition[:base_xpath] = "/config/devices/entry/network/virtual-router/entry[@name='#{paths[0]}']/routing-table/#{@version_label}/static-route/entry[@name='#{paths[1]}']/path-monitor/monitor-destinations" # rubocop:disable Metrics/LineLength
-    context.device.set_config(context.type.definition[:base_xpath], xml_from_should(should[:name], should))
+    context.device.set_config(context.type.definition[:base_xpath], xml_from_should(name, should))
   end
 
-  def update(context, _name, should)
-    paths = should[:route].split('/')
+  def update(context, name, should)
+    paths = name[:route].split('/')
     context.type.definition[:base_xpath] = "/config/devices/entry/network/virtual-router/entry[@name='#{paths[0]}']/routing-table/#{@version_label}/static-route/entry[@name='#{paths[1]}']/path-monitor/monitor-destinations" # rubocop:disable Metrics/LineLength
-    context.device.set_config(context.type.definition[:base_xpath], xml_from_should(should[:name], should))
+    context.device.set_config(context.type.definition[:base_xpath], xml_from_should(name, should))
   end
 
   def delete(context, name)
-    names = name.split('/')
-    context.device.delete_config(context.type.definition[:base_xpath] + "/entry[@name='#{names[0]}']/routing-table/#{@version_label}/static-route/entry[@name='#{names[1]}']/path-monitor/monitor-destinations/entry[@name='#{names[2]}']") # rubocop:disable Metrics/LineLength
+    names = name[:route].split('/')
+    context.device.delete_config(context.type.definition[:base_xpath] + "/entry[@name='#{names[0]}']/routing-table/#{@version_label}/static-route/entry[@name='#{names[1]}']/path-monitor/monitor-destinations/entry[@name='#{name[:path]}']") # rubocop:disable Metrics/LineLength
   end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'xml_from_should(name, should)' do |test_data, provider|
   test_data.each do |test|
     it "creates expected XML for `#{test[:desc]}`" do
-      expect(provider.xml_from_should(test[:attrs][:name], test[:attrs])).to eq(test[:xml].gsub(%r{\n(\s*[^<])?}, ''))
+      expect(provider.xml_from_should((test[:attrs][:name]) ? test[:attrs][:name] : test[:name], test[:attrs])).to eq(test[:xml].gsub(%r{\n(\s*[^<])?}, ''))
     end
   end
 end

--- a/spec/unit/puppet/provider/panos_path_monitor_base_spec.rb
+++ b/spec/unit/puppet/provider/panos_path_monitor_base_spec.rb
@@ -37,10 +37,14 @@ RSpec.describe Puppet::Provider::PanosPathMonitorBase do
     end
   end
 
-  describe '#xml_from_should(_name, should)' do
+  describe '#xml_from_should(name, should)' do
     test_data = [
       {
         desc: 'a full example',
+        name: {
+          path:   'path monitor',
+          route:  'example vr/test route 1',
+        },
         attrs: {
           route:        'example vr/test route 1',
           path:         'path monitor',
@@ -60,6 +64,10 @@ RSpec.describe Puppet::Provider::PanosPathMonitorBase do
       },
       {
         desc: 'essentials example',
+        name: {
+          path:   'path monitor',
+          route:  'example vr/test route 1',
+        },
         attrs: {
           route:        'example vr/test route 1',
           path:         'path monitor',
@@ -168,51 +176,53 @@ EOF
     end
   end
 
-  describe '#create(context, _name, should)' do
+  describe '#create(context, name, should)' do
     context 'when called' do
       let(:expected_path) do
         '/config/devices/entry/network/virtual-router/entry[@name=\'foo\']/routing-table/ip/static-route/entry[@name=\'bar\']/path-monitor/monitor-destinations'
       end
-      let(:should_values) do
+      let(:namevars) do
         {
-          name: 'foo',
-          route: 'foo/bar',
+          title:  'foo/bar/path',
+          route:  'foo/bar',
+          path:   'path',
         }
       end
       let(:mystruct) { {} }
 
       it 'will call set_config' do
         expect(typedef).to receive(:definition).and_return(mystruct).twice
-        expect(provider).to receive(:xml_from_should).with('foo', should_values)
+        expect(provider).to receive(:xml_from_should).with(namevars, anything)
         expect(device).to receive(:set_config).with(expected_path, anything)
-        provider.create(context, 'name', should_values)
+        provider.create(context, namevars, anything)
       end
     end
   end
 
-  describe '#update(context, _name, should)' do
+  describe '#update(context, name, should)' do
     context 'when called' do
       let(:expected_path) do
         '/config/devices/entry/network/virtual-router/entry[@name=\'foo\']/routing-table/ip/static-route/entry[@name=\'bar\']/path-monitor/monitor-destinations'
       end
-      let(:should_values) do
+      let(:namevars) do
         {
-          name: 'foo',
           route: 'foo/bar',
+          path:  'moo',
+          title: 'foo/bar/moo',
         }
       end
       let(:mystruct) { {} }
 
       it 'will call set_config' do
         expect(typedef).to receive(:definition).and_return(mystruct).twice
-        expect(provider).to receive(:xml_from_should).with('foo', should_values)
+        expect(provider).to receive(:xml_from_should).with(namevars, anything)
         expect(device).to receive(:set_config).with(expected_path, anything)
-        provider.update(context, 'name', should_values)
+        provider.update(context, namevars, anything)
       end
     end
   end
 
-  describe '#delete(context, name, vr_name)' do
+  describe '#delete(context, name)' do
     context 'when called' do
       let(:expected_path) do
         '/some_xpath/entry[@name=\'bar\']/routing-table/ip/static-route/entry[@name=\'bar\']/path-monitor/monitor-destinations/entry[@name=\'moo\']'
@@ -222,11 +232,18 @@ EOF
           base_xpath: '/some_xpath',
         }
       end
+      let(:namevars) do
+        {
+          title: 'bar/bar/moo',
+          route: 'bar/bar',
+          path:  'moo',
+        }
+      end
 
       it 'will call delete_config' do
         expect(typedef).to receive(:definition).and_return(mystruct)
         expect(device).to receive(:delete_config).with(expected_path)
-        provider.delete(context, 'bar/bar/moo')
+        provider.delete(context, namevars)
       end
     end
   end


### PR DESCRIPTION
PDK-1143 allows the resource_api to work nicely with composite providers, this PR is a refactor of the `path_monitor` and `static_routes` which work with composite namevars.