### PR TITLE
(FM-7496) fix for running apply runs from a PE/PS installation

### DIFF
--- a/lib/puppet/provider/panos_address/panos_address.rb
+++ b/lib/puppet/provider/panos_address/panos_address.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_address type using the Resource API.
 class Puppet::Provider::PanosAddress::PanosAddress < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_address/panos_address.rb
+++ b/lib/puppet/provider/panos_address/panos_address.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_address_group/panos_address_group.rb
+++ b/lib/puppet/provider/panos_address_group/panos_address_group.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_address_group type using the Resource API.
 class Puppet::Provider::PanosAddressGroup::PanosAddressGroup < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_address_group/panos_address_group.rb
+++ b/lib/puppet/provider/panos_address_group/panos_address_group.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_admin/panos_admin.rb
+++ b/lib/puppet/provider/panos_admin/panos_admin.rb
@@ -1,7 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'rexml/xpath'
-require 'builder'
 require 'base64'
 
 # Implementation for the panos_admin type using the Resource API.

--- a/lib/puppet/provider/panos_admin/panos_admin.rb
+++ b/lib/puppet/provider/panos_admin/panos_admin.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'rexml/xpath'
 require 'builder'

--- a/lib/puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands.rb
+++ b/lib/puppet/provider/panos_arbitrary_commands/panos_arbitrary_commands.rb
@@ -1,9 +1,12 @@
 require 'puppet/resource_api/simple_provider'
-require 'rexml/xpath'
-require 'builder'
 
 # provider to handle arbitrary configuration commands against a PANOS device using the Resource API.
 class Puppet::Provider::PanosArbitraryCommands::PanosArbitraryCommands < Puppet::ResourceApi::SimpleProvider
+  def initialize
+    require 'rexml/xpath'
+    require 'builder'
+  end
+
   # to ensure that the manifest xml matches the API format
   #
   # e.g.

--- a/lib/puppet/provider/panos_ipv6_path_monitor/panos_ipv6_path_monitor.rb
+++ b/lib/puppet/provider/panos_ipv6_path_monitor/panos_ipv6_path_monitor.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_path_monitor_base'
+require_relative '../panos_path_monitor_base'
 
 # Implementation for the panos_ipv6_path_monitor type using the Resource API.
 class Puppet::Provider::PanosIpv6PathMonitor::PanosIpv6PathMonitor < Puppet::Provider::PanosPathMonitorBase

--- a/lib/puppet/provider/panos_ipv6_static_route/panos_ipv6_static_route.rb
+++ b/lib/puppet/provider/panos_ipv6_static_route/panos_ipv6_static_route.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_static_route_base'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_ipv6_static_route type using the Resource API.
 class Puppet::Provider::PanosIpv6StaticRoute::PanosIpv6StaticRoute < Puppet::Provider::PanosStaticRouteBase

--- a/lib/puppet/provider/panos_ipv6_static_route/panos_ipv6_static_route.rb
+++ b/lib/puppet/provider/panos_ipv6_static_route/panos_ipv6_static_route.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_static_route_base'
+require_relative '../panos_static_route_base'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
+++ b/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
+++ b/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_NAT_policy type using the Resource API.
 class Puppet::Provider::PanosNatPolicy::PanosNatPolicy < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_path_monitor/panos_path_monitor.rb
+++ b/lib/puppet/provider/panos_path_monitor/panos_path_monitor.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_path_monitor_base'
+require_relative '../panos_path_monitor_base'
 
 # Implementation for the panos_path_monitor type using the Resource API.
 class Puppet::Provider::PanosPathMonitor::PanosPathMonitor < Puppet::Provider::PanosPathMonitorBase

--- a/lib/puppet/provider/panos_path_monitor_base.rb
+++ b/lib/puppet/provider/panos_path_monitor_base.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative 'panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_path_monitor_base.rb
+++ b/lib/puppet/provider/panos_path_monitor_base.rb
@@ -1,11 +1,10 @@
 require_relative 'panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_path_monitor_base type using the Resource API, which has been implemented to remove the common functionality of the ipv4 and ipv6 static routes,
 # which path monitors are associated with
 class Puppet::Provider::PanosPathMonitorBase < Puppet::Provider::PanosProvider
   def initialize(version_label)
+    super()
     @version_label = version_label
   end
 

--- a/lib/puppet/provider/panos_provider.rb
+++ b/lib/puppet/provider/panos_provider.rb
@@ -1,9 +1,13 @@
 require 'puppet/resource_api/simple_provider'
-require 'rexml/xpath'
-require 'builder'
 
 # A base provider for all PANOS providers
 class Puppet::Provider::PanosProvider < Puppet::ResourceApi::SimpleProvider
+  def initialize
+    require 'rexml/document'
+    require 'rexml/xpath'
+    require 'builder'
+  end
+
   def get(context)
     config = context.device.get_config(context.type.definition[:base_xpath] + '/entry')
     config.elements.collect('/response/result/entry') do |entry| # rubocop:disable Style/CollectionMethods

--- a/lib/puppet/provider/panos_security_policy_rule/panos_security_policy_rule.rb
+++ b/lib/puppet/provider/panos_security_policy_rule/panos_security_policy_rule.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_security_policy_rule type using the Resource API.
 class Puppet::Provider::PanosSecurityPolicyRule::PanosSecurityPolicyRule < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_security_policy_rule/panos_security_policy_rule.rb
+++ b/lib/puppet/provider/panos_security_policy_rule/panos_security_policy_rule.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_service/panos_service.rb
+++ b/lib/puppet/provider/panos_service/panos_service.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_service_type type using the Resource API.
 class Puppet::Provider::PanosService::PanosService < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_service/panos_service.rb
+++ b/lib/puppet/provider/panos_service/panos_service.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_service_group/panos_service_group.rb
+++ b/lib/puppet/provider/panos_service_group/panos_service_group.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_service_group type using the Resource API.
 class Puppet::Provider::PanosServiceGroup::PanosServiceGroup < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_service_group/panos_service_group.rb
+++ b/lib/puppet/provider/panos_service_group/panos_service_group.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_static_route/panos_static_route.rb
+++ b/lib/puppet/provider/panos_static_route/panos_static_route.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_static_route_base'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_static_route type using the Resource API.
 class Puppet::Provider::PanosStaticRoute::PanosStaticRoute < Puppet::Provider::PanosStaticRouteBase

--- a/lib/puppet/provider/panos_static_route/panos_static_route.rb
+++ b/lib/puppet/provider/panos_static_route/panos_static_route.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_static_route_base'
+require_relative '../panos_static_route_base'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_static_route_base.rb
+++ b/lib/puppet/provider/panos_static_route_base.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative 'panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_static_route_base.rb
+++ b/lib/puppet/provider/panos_static_route_base.rb
@@ -1,10 +1,9 @@
 require_relative 'panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_static_route_base type using the Resource API, which has been implemented to remove the common functionality of the ipv4 and ipv6 static routes.
 class Puppet::Provider::PanosStaticRouteBase < Puppet::Provider::PanosProvider
   def initialize(version_label)
+    super()
     @version_label = version_label
   end
 

--- a/lib/puppet/provider/panos_tag/panos_tag.rb
+++ b/lib/puppet/provider/panos_tag/panos_tag.rb
@@ -1,10 +1,9 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_tags type using the Resource API.
 class Puppet::Provider::PanosTag::PanosTag < Puppet::Provider::PanosProvider
   def initialize
+    super()
     @code_from_color = {
       'red' => 'color1',
       'green' => 'color2',

--- a/lib/puppet/provider/panos_tag/panos_tag.rb
+++ b/lib/puppet/provider/panos_tag/panos_tag.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_virtual_router/panos_virtual_router.rb
+++ b/lib/puppet/provider/panos_virtual_router/panos_virtual_router.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_virtual_router type using the Resource API.
 class Puppet::Provider::PanosVirtualRouter::PanosVirtualRouter < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_virtual_router/panos_virtual_router.rb
+++ b/lib/puppet/provider/panos_virtual_router/panos_virtual_router.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 

--- a/lib/puppet/provider/panos_zone/panos_zone.rb
+++ b/lib/puppet/provider/panos_zone/panos_zone.rb
@@ -1,6 +1,4 @@
 require_relative '../panos_provider'
-require 'rexml/document'
-require 'builder'
 
 # Implementation for the panos_tags type using the Resource API.
 class Puppet::Provider::PanosZone::PanosZone < Puppet::Provider::PanosProvider

--- a/lib/puppet/provider/panos_zone/panos_zone.rb
+++ b/lib/puppet/provider/panos_zone/panos_zone.rb
@@ -1,4 +1,4 @@
-require 'puppet/provider/panos_provider'
+require_relative '../panos_provider'
 require 'rexml/document'
 require 'builder'
 


### PR DESCRIPTION
If running on a puppetserver it will be unable to locate the base provider `panos_provider`, this commit uses `require_relative` which will allow it to work on a puppetserver.