### PR TITLE
Allow color numbers instead of descriptive names

### DIFF
--- a/lib/puppet/provider/panos_tag/panos_tag.rb
+++ b/lib/puppet/provider/panos_tag/panos_tag.rb
@@ -54,17 +54,18 @@ class Puppet::Provider::PanosTag::PanosTag < Puppet::Provider::PanosProvider
   def canonicalize(_context, resources)
     resources.each do |resource|
       resource[:color] = resource[:color].downcase if resource[:color]
+      resource[:color] = @color_from_code[resource[:color]] if @color_from_code.key?(resource[:color])
     end
     resources
   end
 
   def validate_should(should)
     return unless should.key? :color
-    raise Puppet::ResourceError, 'Please use one of the existing Palo Alto colors.' unless @code_from_color.key? should[:color]
+    raise Puppet::ResourceError, 'Please use one of the existing Palo Alto colors.' unless @code_from_color.key?(should[:color]) || @color_from_code.key?(should[:color])
   end
 
   def munge(entry)
-    entry[:color] = @color_from_code[entry[:color]] if entry[:color]
+    entry[:color] = @color_from_code[entry[:color]] if entry[:color] && @color_from_code.key?(entry[:color])
     entry
   end
 

--- a/lib/puppet/type/panos_tag.rb
+++ b/lib/puppet/type/panos_tag.rb
@@ -6,7 +6,7 @@ Puppet::ResourceApi.register_type(
 This type provides Puppet with the capabilities to manage "tags" objects on Palo Alto devices.
 EOS
   base_xpath: '/config/devices/entry/vsys/entry/tag',
-  features: ['remote_resource'],
+  features: ['remote_resource', 'canonicalize'],
   attributes: {
     name: {
       type:       'Pattern[/^[a-zA-z0-9\-_\s\.]{1,127}$/]',

--- a/spec/fixtures/create.pp
+++ b/spec/fixtures/create.pp
@@ -233,7 +233,10 @@ panos_tag {
   'Test Tag':
     ensure   => 'present',
     color    => 'red',
-    comments => 'comments 123',
+    comments => 'comments 123';
+  'Second Test Tag':
+    ensure => 'present',
+    color  => 'color2';
 }
 
 panos_nat_policy {
@@ -453,7 +456,7 @@ panos_static_route {
     no_install      => $::facts['operatingsystemrelease'] ? {
       '7.1.0' => false,
       '8.1.0' => false,
-    };  
+    };
   'full example VR/route three':
     ensure          => 'present',
     bfd_profile     => 'None',

--- a/spec/fixtures/update.pp
+++ b/spec/fixtures/update.pp
@@ -220,7 +220,10 @@ panos_tag {
   'Test Tag':
     ensure   => 'present',
     color    => 'green',
-    comments => 'comments 123',
+    comments => 'comments 123';
+  'Second Test Tag':
+    ensure => 'present',
+    color  => 'green';
 }
 
 panos_nat_policy {
@@ -486,7 +489,7 @@ if $::facts['operatingsystemrelease'] == '8.1.0' {
     enable            => false,
     hold_time         => '7',
   }
-  
+
   panos_path_monitor {
     'full example VR/route four/path monitor one':
       ensure      => present,

--- a/spec/unit/puppet/provider/panos_tag/panos_tag_spec.rb
+++ b/spec/unit/puppet/provider/panos_tag/panos_tag_spec.rb
@@ -34,13 +34,18 @@ RSpec.describe Puppet::Provider::PanosTag::PanosTag do
       ]
     end
 
-    context 'when resource contains the color `red`' do
+    context 'when resource contains a color name' do
       let(:color) { 'red' }
 
       it { expect(panos_tag.canonicalize(nil, resource)).to eq canonicalised_resource }
     end
-    context 'when resource contains the color `RED`' do
+    context 'when resource contains a color name in upper case' do
       let(:color) { 'RED' }
+
+      it { expect(panos_tag.canonicalize(nil, resource)).to eq canonicalised_resource }
+    end
+    context 'when resource contains a color tag' do
+      let(:color) { 'color1' }
 
       it { expect(panos_tag.canonicalize(nil, resource)).to eq canonicalised_resource }
     end
@@ -63,13 +68,18 @@ RSpec.describe Puppet::Provider::PanosTag::PanosTag do
 
       it { expect { panos_tag.validate_should(entry) }.to raise_error Puppet::ResourceError, %r{Please use one of the existing Palo Alto colors.} }
     end
-    context 'when an valid color is provided' do
+    context 'when a valid color name is provided' do
       let(:entry) { { color: 'red' } }
 
       it { expect { panos_tag.validate_should(entry) }.not_to raise_error }
     end
-    context 'when a color is not provided' do
-      let(:entry) { { name: 'red' } }
+    context 'when a valid color index is provided' do
+      let(:entry) { { color: 'color1' } }
+
+      it { expect { panos_tag.validate_should(entry) }.not_to raise_error }
+    end
+    context 'when no color is provided' do
+      let(:entry) { {} }
 
       it { expect { panos_tag.validate_should(entry) }.not_to raise_error }
     end


### PR DESCRIPTION
"Sometimes, all you need is a hammer."