### PR TITLE
(demo) Update apikey task to be a puppet remote task

### DIFF
--- a/lib/puppet/util/network_device/panos/device.rb
+++ b/lib/puppet/util/network_device/panos/device.rb
@@ -101,6 +101,10 @@ module Puppet::Util::NetworkDevice::Panos
       api.job_request('commit', cmd: '<commit></commit>')
     end
 
+    def apikey
+      api.apikey
+    end
+
     private
 
     def api

--- a/tasks/apikey.json
+++ b/tasks/apikey.json
@@ -1,19 +1,9 @@
 {
   "puppet_task_version": 1,
   "supports_noop": false,
+  "input_method": "stdin",
   "description": "Retrieve a PAN-OS apikey using PAN-OS host, username and password.",
   "parameters": {
-    "host": {
-      "description": "The host to connect to",
-      "type": "String"
-    },
-    "user": {
-      "description": "The user name",
-      "type": "String"
-    },
-    "password": {
-      "description": "The password",
-      "type": "String"
-    }
-  }
+  },
+  "files": [ "panos/lib/puppet/util/network_device/panos/device.rb" ]
 }

--- a/tasks/apikey.rb
+++ b/tasks/apikey.rb
@@ -17,8 +17,25 @@ Puppet[:log_level] = 'debug'
 #### the real task ###
 
 require 'json'
-require 'puppet/util/network_device/panos/device'
+
+def add_plugin_paths(install_dir)
+  Dir.glob(File.join([install_dir, '*'])).each do |mod|
+    $LOAD_PATH << File.join([mod, "lib"])
+  end
+end
 
 params = JSON.parse(ENV['PARAMS'] || STDIN.read)
-device = Puppet::Util::NetworkDevice::Panos::Device.new(params)
+#params = {key: "foo"}
+target = params['_target']
+unless target
+  puts "Panos task must be run on a proxy"
+  exit 1
+end
+
+add_plugin_paths(params['_installdir'])
+
+
+require 'puppet/util/network_device/panos/device'
+
+device = Puppet::Util::NetworkDevice::Panos::Device.new(target)
 puts JSON.generate(apikey: device.apikey)


### PR DESCRIPTION
This shows how tasks can be updated to use the "remote" transport in bolt with credentials stored in inventory instead of passing credentials as params to the task. It also enables running a task to target multiple devices concurrently.

```yaml
nodes:

  - name: nm011qhwxyni6zt.delivery.puppetlabs.net
  - name: pzwsffj7lq4sce1.delivery.puppetlabs.net
    config:
      transport: remote
      remote:
        # it's hard to use the local transport with bundle exec but normally this could be skipped to let it default to localhost
        run-on: nm011qhwxyni6zt.delivery.puppetlabs.net
        type: panos
        user: "admin"
        password: "admin"
```