### PR TITLE
(maint) add resource_api install module as a dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,10 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-panos",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-panos/issues",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/resource_api",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
While not strictly necessary for the operations of the module,
it should be listed to make users aware of the possibility.