### PR TITLE
(FM-7653) implement a standardized install class

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The module provides a Puppet task to manually `commit`, `store_config` to a file
 
 Install the module on either a Puppet master or Puppet agent, by running `puppet module install puppetlabs-panos`. To install from source, download the tar file from GitHub and run `puppet module install <file_name>.tar.gz --force`.
 
-This module installs the Builder gem; and Puppet Resource API gem, if necessary. To activate the Puppet Resource API gem on a master, a reload of the puppetserver service is necessary. In most cases, this should happen automatically and cause little to no interruption to service.
+This module installs the Builder and Puppet Resource API gems, if necessary. To activate the Puppet Resource API gem on the master, reload the puppetserver service. In most cases, this happens automatically and causes little to no interruption to service.
 
 ### Setup Requirements
 
@@ -37,13 +37,13 @@ The PANOS module requires access to the device's web management interface.
 
 #### Proxy Puppet agent
 
-Since a Puppet agent is not available for Palo Alto devices (and, seriously, who would want to run an agent on them?) we need a proxy Puppet agent (either a compile master, or another agent) to run Puppet on behalf of the device.
+Since a Puppet agent is not available for Palo Alto devices, we need a proxy Puppet agent (either a compile master, or another agent) to run Puppet on behalf of the device.
 
 #### Install dependencies
 
 Once the module has been installed, install dependencies of the module:
 
-1. Classify or apply the `panos` class on each master (master of masters, and if present, compile masters and replica master) that needs serve catalogs for this module.
+1. Classify or apply the `panos` class on each master (master of masters, and if present, compile masters and replica master) that serves catalogs for this module.
 1. Classify or apply the `panos` class on each proxy Puppet agent that proxies for Palo Alto devices.
 
 Run puppet agent -t on the master(s) before using the module on the agent(s).

--- a/README.md
+++ b/README.md
@@ -19,30 +19,40 @@
 
 The PANOS module configures Palo Alto firewalls running PANOS 7.1.0 or PANOS 8.1.0.
 
-When committing changes to resources, include `panos_commit` in your manifest, or execute the `commit` task. You must do this before they can be made available to the running configuration. 
+When committing changes to resources, include `panos_commit` in your manifest, or execute the `commit` task. You must do this before they can be made available to the running configuration.
 
 The module provides a Puppet task to manually `commit`, `store_config` to a file, and `set_config` from a file.
 
 ## Setup
 
-Install the module on either a Puppet master or Puppet agent machine, by running `puppet module install puppetlabs-panos`. To install from source, download the tar file from GitHub and run `puppet module install <file_name>.tar.gz --force`.
+Install the module on either a Puppet master or Puppet agent, by running `puppet module install puppetlabs-panos`. To install from source, download the tar file from GitHub and run `puppet module install <file_name>.tar.gz --force`.
+
+This module installs the Builder gem; and Puppet Resource API gem, if necessary. To activate the Puppet Resource API gem on a master, a reload of the puppetserver service is necessary. In most cases, this should happen automatically and cause little to no interruption to service.
 
 ### Setup Requirements
 
-The PANOS module requires access to the device's web management interface. You will also need to install the dependences.
+#### Device access
 
-The module has a dependency on the `resource_api` - it will be installed when the module is installed. Alternatively, it can be manually installed by running `puppet module install puppetlabs-resource_api`, or by following the setup instructions in the [Resource API README](https://github.com/puppetlabs/puppetlabs-resource_api#resource_api).
+The PANOS module requires access to the device's web management interface.
 
-### Manual Test Setup
+#### Proxy Puppet agent
 
-Once the module has been installed, classify the appropriate class:
+Since a Puppet agent is not available for Palo Alto devices (and, seriously, who would want to run an agent on them?) we need a proxy Puppet agent (either a compile master, or another agent) to run Puppet on behalf of the device.
 
-* On each puppetserver or PE master that needs to manage PANOS devices, classify or apply the `panos::server` by running `puppet apply -e 'include panos::server'`.
-* On each Puppet agent that needs to manage PANOS devices, classify or apply the `panos::agent` class by running `puppet apply -e 'include panos::agent'`.
+#### Install dependencies
+
+Once the module has been installed, install dependencies of the module:
+
+1. Classify or apply the `panos` class on each master (master of masters, and if present, compile masters and replica master) that needs serve catalogs for this module.
+1. Classify or apply the `panos` class on each proxy Puppet agent that proxies for Palo Alto devices.
+
+Run puppet agent -t on the master(s) before using the module on the agent(s).
 
 ### Getting started with PANOS
 
-To get started, create or edit `/etc/puppetlabs/puppet/device.conf`, add a section for the device (this will become the device's `certname`), specify a type of `panos`, and specify a `url` to a credentials file. For example:
+To get started, create or edit `/etc/puppetlabs/puppet/device.conf` on the proxy Puppet agent, add a section for the device (this will become the device's `certname`), specify a type of `panos`, and specify a `url` to a credentials file.
+
+For example:
 
 ```INI
 [firewall.example.com]

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,13 +1,13 @@
-# @summary
-#   This resource manages the `resource_api::agent` and the builder gem on an agent.
+# @summary This class installs dependencies of this module into puppet agent
 #
-# @example
+# @example Declaring the class
 #   include panos::agent
 #
-# Deprecated by panos::install::agent
-
+# @note Deprecated, use panos::install::agent
 class panos::agent {
+
   include resource_api::agent
+
   package { 'builder':
     ensure   => present,
     provider => 'puppet_gem',

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -3,6 +3,9 @@
 #
 # @example
 #   include panos::agent
+#
+# Deprecated by panos::install::agent
+
 class panos::agent {
   include resource_api::agent
   package { 'builder':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,7 @@
+# @summary This class calls the panos::install class.
+#
+# @example Declaring the class
+#   include panos
 class panos {
   class { 'panos::install': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,3 @@
+class panos {
+  class { 'panos::install': }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,17 +1,8 @@
-# Install device module dependencies on a puppet agent or master.
+# @summary This class installs dependencies of this module
+#          into the puppet agent, and/or the puppetserver service.
 #
-# A proxy agent needs to be classified with this class
-# before it can manage devices with this module.
-#
-# Every master: master of masters, and if present, compile masters and replica
-# needs to be classified with this class
-# before it can compile catalogs for devices with this module.
-#
-# @summary Install dependencies into the puppet agent and puppetserver service
-#
-# @example
+# @example Declaring the class
 #   include panos::install
-
 class panos::install {
 
   include panos::install::agent
@@ -19,5 +10,4 @@ class panos::install {
   if $facts['puppetserver_installed'] {
     include panos::install::master
   }
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,23 @@
+# Install device module dependencies on a puppet agent or master.
+#
+# A proxy agent needs to be classified with this class
+# before it can manage devices with this module.
+#
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class
+# before it can compile catalogs for devices with this module.
+#
+# @summary Install dependencies into the puppet agent and puppetserver service
+#
+# @example
+#   include panos::install
+
+class panos::install {
+
+  include panos::install::agent
+
+  if $facts['puppetserver_installed'] {
+    include panos::install::master
+  }
+
+}

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,0 +1,17 @@
+# Install device module dependencies on a puppet agent.
+
+# @summary Install dependencies into the puppet agent
+#
+# @example
+#   include panos::install::agent
+
+class panos::install::agent {
+  include resource_api::install
+
+  package { 'builder':
+    ensure   => present,
+    provider => 'puppet_gem',
+  }
+
+}
+

--- a/manifests/install/agent.pp
+++ b/manifests/install/agent.pp
@@ -1,17 +1,13 @@
-# Install device module dependencies on a puppet agent.
-
-# @summary Install dependencies into the puppet agent
+# @summary This class install dependencies of this module into puppet agent
 #
-# @example
+# @example Declaring the class
 #   include panos::install::agent
-
 class panos::install::agent {
+
   include resource_api::install
 
   package { 'builder':
     ensure   => present,
     provider => 'puppet_gem',
   }
-
 }
-

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,15 +1,8 @@
-# Install device module dependencies on a puppet master.
-
-# Every master: master of masters, and if present, compile masters and replica
-# needs to be classified with this class
-# before it can compile catalogs for devices with this module.
-
-# @summary Install dependencies into the puppetserver service and restart
+# @summary This class installs dependencies of this module into puppetserver,
+#          and restarts the puppetserver service to activate.
 #
-# @example
+# @example Declaring the class
 #   include panos::install::master
-
 class panos::install::master {
   include resource_api::install::master
 }
-

--- a/manifests/install/master.pp
+++ b/manifests/install/master.pp
@@ -1,0 +1,15 @@
+# Install device module dependencies on a puppet master.
+
+# Every master: master of masters, and if present, compile masters and replica
+# needs to be classified with this class
+# before it can compile catalogs for devices with this module.
+
+# @summary Install dependencies into the puppetserver service and restart
+#
+# @example
+#   include panos::install::master
+
+class panos::install::master {
+  include resource_api::install::master
+}
+

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,6 +3,9 @@
 #
 # @example
 #   include panos::server
+#
+# Deprecated by panos::install::master
+
 class panos::server {
   include resource_api::server
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,11 +1,10 @@
-# @summary
-#   This resource manages the `resource_api::server` on the server.
+# @summary This class installs dependencies of this module into puppetserver,
+#          and restarts the puppetserver service to activate.
 #
-# @example
+# @example Declaring the class
 #   include panos::server
 #
-# Deprecated by panos::install::master
-
+# @note Deprecated, use panos::install::master
 class panos::server {
   include resource_api::server
 }


### PR DESCRIPTION
With this commit ...

Simply including the module will include the ::install class.
The ::install class will install dependencies on agent or master.

(A custom puppetserver_installed fact, defined by puppetlabs-resource_api,
which is a dependency of this module, is used to detect a master.)

Optionally, the ::install::agent and ::install::master classes can be declared
directly, allowing the user to specify their parameters ... if any.