### PR TITLE
(FM-7971) backwards compatibility with PE 2019.0

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,6 +10,7 @@ Gemfile:
         ref: 'master'
       - gem: 'puppet-resource_api'
         version: '>= 1.8.1'
+        from_env: 'RSAPI_GEM_VERSION'
         # git: 'https://github.com/puppetlabs/puppet-resource_api.git'
         # ref: 'master'
       # required for internal pipelines
@@ -45,6 +46,11 @@ spec/spec_helper.rb:
   simplecov: true
   branches:
     - release
+  includes:
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0.0" RSAPI_GEM_VERSION="~> 1.6.0" CHECK=parallel_spec
+      rvm: 2.5.1
+      stage: spec
 appveyor.yml:
   delete: true
 .gitlab-ci.yml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ matrix:
     -
       env: DEPLOY_TO_FORGE=yes
       stage: deploy
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0.0" RSAPI_GEM_VERSION="~> 1.6.0" CHECK=parallel_spec
+      rvm: 2.5.1
+      stage: spec
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -17,23 +17,23 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "webmock",                                       require: false
-  gem "builder", '~> 3.2.2',                           require: false
-  gem "puppet-strings",                                require: false, git: 'https://github.com/puppetlabs/puppet-strings.git', ref: 'master'
-  gem "puppet-resource_api", '>= 1.8.1',               require: false
-  gem "beaker-hostgenerator", '~> 1.1.15',             require: false
-  gem "bolt",                                          require: false
-  gem "github_changelog_generator",                    require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
+  gem "fast_gettext", '1.1.0',                                                     require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                                              require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                                                     require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                                                           require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                                                           require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0',                                                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "puppet-module-posix-default-r#{minor_version}",                             require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}",                                 require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}",                               require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}",                                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "webmock",                                                                   require: false
+  gem "builder", '~> 3.2.2',                                                       require: false
+  gem "puppet-strings",                                                            require: false, git: 'https://github.com/puppetlabs/puppet-strings.git', ref: 'master'
+  gem "puppet-resource_api", *location_for(ENV['RSAPI_GEM_VERSION'] || '>= 1.8.1')
+  gem "beaker-hostgenerator", '~> 1.1.15',                                         require: false
+  gem "bolt",                                                                      require: false
+  gem "github_changelog_generator",                                                require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ TLSv1_2
 
 For more information refer to the [OpenSSL docs](https://www.openssl.org/docs/man1.1.1/man3/SSL_version.html).
 
-*NOTE*: Although not advisable, you can turn off SSL by setting `ssl.verify: off`. In doing so you increase the risk of your firewall configuration being hijacked by a potential attacker.
+*NOTE*: Although not advisable, you can turn off SSL by setting `ssl: false`. In doing so you increase the risk of your firewall configuration being hijacked by a potential attacker.
 
 ```
 host: 10.0.10.20

--- a/lib/puppet/util/network_device/panos/device.rb
+++ b/lib/puppet/util/network_device/panos/device.rb
@@ -1,5 +1,9 @@
 require 'puppet'
-require 'puppet/resource_api/transport/wrapper'
+begin
+  require 'puppet/resource_api/transport/wrapper'
+rescue LoadError
+  require 'puppet_x/puppetlabs/panos/transport_shim'
+end
 # force registering the transport
 require 'puppet/transport/schema/panos'
 

--- a/lib/puppet/util/task_helper.rb
+++ b/lib/puppet/util/task_helper.rb
@@ -12,7 +12,11 @@ class Puppet::Util::TaskHelper
   end
 
   def transport
-    require 'puppet/resource_api/transport'
+    begin
+      require 'puppet/resource_api/transport'
+    rescue LoadError
+      require 'puppet_x/puppetlabs/panos/transport_shim'
+    end
 
     @transport[@transport_name] ||= Puppet::ResourceApi::Transport.connect(@transport_name, credentials)
   end

--- a/lib/puppet_x/puppetlabs/panos/transport_shim.rb
+++ b/lib/puppet_x/puppetlabs/panos/transport_shim.rb
@@ -1,0 +1,329 @@
+require 'hocon'
+require 'hocon/config_syntax'
+require 'pathname'
+require 'puppet/resource_api'
+require 'puppet/resource_api/type_definition'
+require 'puppet/resource_api/data_type_handling'
+require 'puppet/util/network_device'
+
+# This is monkey patches for patching in transport conversion
+# from RSAPI transport work which is in 1.8.x, whereas
+# puppet 6.0.x has 1.6.x
+module Puppet::ResourceApi
+  # monkey patch for the transport context for continued
+  # module support
+  class BaseContext
+    attr_reader :type
+
+    def initialize(definition)
+      if definition.is_a?(Hash)
+        # this is only for backwards compatibility
+        @type = Puppet::ResourceApi::TypeDefinition.new(definition)
+      elsif definition.is_a? Puppet::ResourceApi::BaseTypeDefinition
+        @type = definition
+      else
+        raise ArgumentError, 'BaseContext requires definition to be a child of Puppet::ResourceApi::BaseTypeDefinition, not <%{actual_type}>' % { actual_type: definition.class }
+      end
+    end
+
+    def transport
+      device.transport
+    end
+  end
+  # pre-declare class
+  class BaseTypeDefinition; end
+
+  # RSAPI Transport schema
+  class TransportSchemaDef < BaseTypeDefinition
+    def initialize(definition)
+      super(definition, :connection_info)
+    end
+
+    def validate(resource)
+      # enforce mandatory attributes
+      missing_attrs = []
+
+      attributes.each do |name, _options|
+        type = @data_type_cache[attributes[name][:type]]
+
+        if resource[name].nil? && !(type.instance_of? Puppet::Pops::Types::POptionalType)
+          missing_attrs << name
+        end
+      end
+
+      error_msg = "The following mandatory attributes were not provided:\n    *  " + missing_attrs.join(", \n    *  ")
+      raise Puppet::ResourceError, error_msg if missing_attrs.any?
+    end
+
+    def notify_schema_errors(message)
+      raise Puppet::DevError, message
+    end
+  end
+
+  # Base RSAPI schema Object
+  class BaseTypeDefinition
+    attr_reader :definition, :attributes
+
+    def initialize(definition, attr_key)
+      @data_type_cache = {}
+      validate_schema(definition, attr_key)
+      # store the validated definition
+      @definition = definition
+    end
+
+    def name
+      definition[:name]
+    end
+
+    def namevars
+      @namevars ||= attributes.select { |_name, options|
+        options.key?(:behaviour) && options[:behaviour] == :namevar
+      }.keys
+    end
+
+    def validate_schema(definition, attr_key)
+      raise Puppet::DevError, '%{type_class} must be a Hash, not `%{other_type}`' % { type_class: self.class.name, other_type: definition.class } unless definition.is_a?(Hash)
+      @attributes = definition[attr_key]
+      raise Puppet::DevError, '%{type_class} must have a name' % { type_class: self.class.name } unless definition.key? :name
+      raise Puppet::DevError, '%{type_class} must have `%{attr_key}`' % { type_class: self.class.name, attrs: attr_key } unless definition.key? attr_key
+      unless attributes.is_a?(Hash)
+        raise Puppet::DevError, '`%{name}.%{attrs}` must be a hash, not `%{other_type}`' % {
+          name: definition[:name], attrs: attr_key, other_type: attributes.class
+        }
+      end
+
+      attributes.each do |key, attr|
+        raise Puppet::DevError, "`#{definition[:name]}.#{key}` must be a Hash, not a #{attr.class}" unless attr.is_a? Hash
+        raise Puppet::DevError, "`#{definition[:name]}.#{key}` has no type" unless attr.key? :type
+        Puppet.warning("`#{definition[:name]}.#{key}` has no docs") unless attr.key? :desc
+
+        # validate the type by attempting to parse into a puppet type
+        @data_type_cache[attributes[key][:type]] ||=
+          Puppet::ResourceApi::DataTypeHandling.parse_puppet_type(
+            key,
+            attributes[key][:type],
+          )
+
+        # fixup any weird behavior  ;-)
+        next unless attr[:behavior]
+        if attr[:behaviour]
+          raise Puppet::DevError, "the '#{key}' attribute has both a `behavior` and a `behaviour`, only use one"
+        end
+        attr[:behaviour] = attr[:behavior]
+        attr.delete(:behavior)
+      end
+    end
+
+    # validates a resource hash against its type schema
+    def check_schema(resource, message_prefix = nil)
+      namevars.each do |namevar|
+        if resource[namevar].nil?
+          raise Puppet::ResourceError, "`#{name}.get` did not return a value for the `#{namevar}` namevar attribute"
+        end
+      end
+
+      message_prefix = 'Provider returned data that does not match the Type Schema' if message_prefix.nil?
+      message = "#{message_prefix} for `#{name}[#{resource[namevars.first]}]`"
+
+      rejected_keys = check_schema_keys(resource)
+      bad_values = check_schema_values(resource)
+
+      unless rejected_keys.empty?
+        message += "\n Unknown attribute:\n"
+        rejected_keys.each { |key, _value| message += "    * #{key}\n" }
+      end
+      unless bad_values.empty?
+        message += "\n Value type mismatch:\n"
+        bad_values.each { |key, value| message += "    * #{key}: #{value}\n" }
+      end
+
+      return if rejected_keys.empty? && bad_values.empty?
+
+      notify_schema_errors(message)
+    end
+
+    def notify_schema_errors(message)
+      if Puppet.settings[:strict] == :off
+        Puppet.debug(message)
+      elsif Puppet.settings[:strict] == :warning
+        Puppet::ResourceApi.warning_count += 1
+        Puppet.warning(message) if Puppet::ResourceApi.warning_count <= 100 # maximum number of schema warnings to display in a run
+      elsif Puppet.settings[:strict] == :error
+        raise Puppet::DevError, message
+      end
+    end
+
+    # Returns an array of keys that where not found in the type schema
+    # No longer modifies the resource passed in
+    def check_schema_keys(resource)
+      rejected = []
+      resource.reject { |key| rejected << key if key != :title && attributes.key?(key) == false }
+      rejected
+    end
+
+    # Returns a hash of keys and values that are not valid
+    # does not modify the resource passed in
+    def check_schema_values(resource)
+      bad_vals = {}
+      resource.each do |key, value|
+        next unless attributes[key]
+        type = @data_type_cache[attributes[key][:type]]
+        is_sensitive = (attributes[key].key?(:sensitive) && (attributes[key][:sensitive] == true))
+        error_message = Puppet::ResourceApi::DataTypeHandling.try_validate(
+          type,
+          value,
+          '',
+        )
+        if is_sensitive
+          bad_vals[key] = '<< redacted value >> ' + error_message unless error_message.nil?
+        else
+          bad_vals[key] = value unless error_message.nil?
+        end
+      end
+      bad_vals
+    end
+  end
+
+  def register_transport(schema)
+    Puppet::ResourceApi::Transport.register(schema)
+  end
+  module_function :register_transport
+end
+
+# Remote target transport API
+module Puppet::ResourceApi::Transport
+  def register(schema)
+    raise Puppet::DevError, 'requires a hash as schema, not `%{other_type}`' % { other_type: schema.class } unless schema.is_a? Hash
+    raise Puppet::DevError, 'requires a `:name`' unless schema.key? :name
+    raise Puppet::DevError, 'requires `:desc`' unless schema.key? :desc
+    raise Puppet::DevError, 'requires `:connection_info`' unless schema.key? :connection_info
+    raise Puppet::DevError, '`:connection_info` must be a hash, not `%{other_type}`' % { other_type: schema[:connection_info].class } unless schema[:connection_info].is_a?(Hash)
+
+    init_transports
+    unless @transports[@environment][schema[:name]].nil?
+      raise Puppet::DevError, 'Transport `%{name}` is already registered for `%{environment}`' % {
+        name: schema[:name],
+        environment: @environment,
+      }
+    end
+    @transports[@environment][schema[:name]] = Puppet::ResourceApi::TransportSchemaDef.new(schema)
+  end
+  module_function :register
+
+  # retrieve a Hash of transport schemas, keyed by their name.
+  def list
+    init_transports
+    Marshal.load(Marshal.dump(@transports[@environment]))
+  end
+  module_function :list
+
+  def connect(name, connection_info)
+    validate(name, connection_info)
+    require "puppet/transport/#{name}"
+    class_name = name.split('_').map { |e| e.capitalize }.join
+    Puppet::Transport.const_get(class_name).new(get_context(name), wrap_sensitive(name, connection_info))
+  end
+  module_function :connect
+
+  def inject_device(name, transport)
+    transport_wrapper = Puppet::ResourceApi::Transport::Wrapper.new(name, transport)
+
+    if Puppet::Util::NetworkDevice.respond_to?(:set_device)
+      Puppet::Util::NetworkDevice.set_device(name, transport_wrapper)
+    else
+      Puppet::Util::NetworkDevice.instance_variable_set(:@current, transport_wrapper)
+    end
+  end
+  module_function :inject_device
+
+  def self.validate(name, connection_info)
+    init_transports
+    require "puppet/transport/schema/#{name}" unless @transports[@environment].key? name
+    transport_schema = @transports[@environment][name]
+    if transport_schema.nil?
+      raise Puppet::DevError, 'Transport for `%{target}` not registered with `%{environment}`' % {
+        target: name,
+        environment: @environment,
+      }
+    end
+    message_prefix = 'The connection info provided does not match the Transport Schema'
+    transport_schema.check_schema(connection_info, message_prefix)
+    transport_schema.validate(connection_info)
+  end
+  private_class_method :validate
+
+  def self.get_context(name)
+    require 'puppet/resource_api/puppet_context'
+    Puppet::ResourceApi::PuppetContext.new(@transports[@environment][name])
+  end
+  private_class_method :get_context
+
+  def self.init_transports
+    lookup = Puppet.lookup(:current_environment) if Puppet.respond_to? :lookup
+    @environment =  if lookup.nil?
+                      :transports_default
+                    else
+                      lookup.name
+                    end
+    @transports ||= {}
+    @transports[@environment] ||= {}
+  end
+  private_class_method :init_transports
+
+  def self.wrap_sensitive(name, connection_info)
+    transport_schema = @transports[@environment][name]
+    if transport_schema
+      transport_schema.definition[:connection_info].each do |attr_name, options|
+        if options.key?(:sensitive) && (options[:sensitive] == true) && connection_info.key?(attr_name)
+          connection_info[attr_name] = Puppet::Pops::Types::PSensitiveType::Sensitive.new(connection_info[attr_name])
+        end
+      end
+    end
+    connection_info
+  end
+  private_class_method :wrap_sensitive
+end
+
+# Puppet::ResourceApi::Transport::Wrapper` to interface between the Util::NetworkDevice
+class Puppet::ResourceApi::Transport::Wrapper
+  attr_reader :transport, :schema
+
+  def initialize(name, url_or_config_or_transport)
+    if url_or_config_or_transport.is_a? String
+      url = URI.parse(url_or_config_or_transport)
+      raise "Unexpected url '#{url_or_config_or_transport}' found. Only file:/// URLs for configuration supported at the moment." unless url.scheme == 'file'
+      raise "Trying to load config from '#{url.path}, but file does not exist." if url && !File.exist?(url.path)
+      config = self.class.deep_symbolize(Hocon.load(url.path, syntax: Hocon::ConfigSyntax::HOCON) || {})
+    elsif url_or_config_or_transport.is_a? Hash
+      config = url_or_config_or_transport
+    elsif transport_class?(name, url_or_config_or_transport)
+      @transport = url_or_config_or_transport
+    end
+
+    @transport ||= Puppet::ResourceApi::Transport.connect(name, config)
+    @schema = Puppet::ResourceApi::Transport.list[name]
+  end
+
+  def transport_class?(name, transport)
+    class_name = name.split('_').map { |e| e.capitalize }.join
+    expected = Puppet::Transport.const_get(class_name).to_s
+    expected == transport.class.to_s
+  end
+
+  def facts
+    context = Puppet::ResourceApi::PuppetContext.new(@schema)
+    # @transport.facts + custom_facts  # look into custom facts work by TP
+    @transport.facts(context)
+  end
+
+  def respond_to_missing?(name, _include_private)
+    (@transport.respond_to? name) || super
+  end
+
+  # From https://stackoverflow.com/a/11788082/4918
+  def self.deep_symbolize(obj)
+    return obj.each_with_object({}) { |(k, v), memo| memo[k.to_sym] = deep_symbolize(v); } if obj.is_a? Hash
+    return obj.each_with_object([]) { |v, memo| memo << deep_symbolize(v); } if obj.is_a? Array
+    obj
+  end
+end

--- a/lib/puppet_x/puppetlabs/panos/transport_shim.rb
+++ b/lib/puppet_x/puppetlabs/panos/transport_shim.rb
@@ -56,7 +56,7 @@ module Puppet::ResourceApi
     end
 
     def notify_schema_errors(message)
-      raise Puppet::DevError, message
+      # do nothing to satisfy tasks
     end
   end
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,1 +1,6 @@
 require 'rexml/document'
+begin
+  require 'puppet/resource_api/transport'
+rescue LoadError
+  require 'puppet_x/puppetlabs/panos/transport_shim'
+end

--- a/spec/unit/puppet/util/task_helper_spec.rb
+++ b/spec/unit/puppet/util/task_helper_spec.rb
@@ -1,6 +1,10 @@
 require 'json'
 require 'puppet/util/task_helper'
-require 'puppet/resource_api/transport'
+begin
+  require 'puppet/resource_api/transport'
+rescue LoadError
+  require 'puppet_x/puppetlabs/panos/transport_shim'
+end
 
 RSpec.describe Puppet::Util::TaskHelper do
   let(:helper) { described_class.new('panos') }

--- a/tasks/apikey.json
+++ b/tasks/apikey.json
@@ -8,6 +8,7 @@
   "files": [
     "panos/lib/puppet/util/task_helper.rb",
     "panos/lib/puppet/transport/panos.rb",
-    "panos/lib/puppet/transport/schema/panos.rb"
+    "panos/lib/puppet/transport/schema/panos.rb",
+    "panos/lib/puppet_x/puppetlabs/panos/transport_shim.rb"
   ]
 }

--- a/tasks/commit.json
+++ b/tasks/commit.json
@@ -8,6 +8,7 @@
   "files": [
     "panos/lib/puppet/util/task_helper.rb",
     "panos/lib/puppet/transport/panos.rb",
-    "panos/lib/puppet/transport/schema/panos.rb"
+    "panos/lib/puppet/transport/schema/panos.rb",
+    "panos/lib/puppet_x/puppetlabs/panos/transport_shim.rb"
   ]
 }

--- a/tasks/set_config.json
+++ b/tasks/set_config.json
@@ -16,6 +16,7 @@
   "files": [
     "panos/lib/puppet/util/task_helper.rb",
     "panos/lib/puppet/transport/panos.rb",
-    "panos/lib/puppet/transport/schema/panos.rb"
+    "panos/lib/puppet/transport/schema/panos.rb",
+    "panos/lib/puppet_x/puppetlabs/panos/transport_shim.rb"
   ]
 }


### PR DESCRIPTION
This PR will add support to the module to work with RSAPI 1.6.x that Puppet 6.0.x is shipped with. This PR could be reverted once STS of PE 2019.0 is over.