### PR TITLE
(FM-8110) fix panos_nat_policy source address translation

### DIFF
--- a/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
+++ b/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
@@ -57,10 +57,10 @@ class Puppet::Provider::PanosNatPolicy::PanosNatPolicy < Puppet::Provider::Panos
                   builder.member(addr)
                 end
               end
-            elsif should[:SAT_interface]
+            elsif should[:sat_interface]
               builder.__send__('interface-address') do
-                builder.ip(should[:SAT_interface_ip])
-                builder.interface(should[:SAT_interface])
+                builder.ip(should[:sat_interface_ip]) if should[:sat_interface_ip]
+                builder.interface(should[:sat_interface])
               end
             end
           end

--- a/lib/puppet/type/panos_nat_policy.rb
+++ b/lib/puppet/type/panos_nat_policy.rb
@@ -109,12 +109,12 @@ The size of the address range is limited by the type of address pool:
 DESC
       xpath: 'local-name(source-translation/*[1])',
     },
-    SAT_interface: {
+    sat_interface: {
       type:  'Optional[String]',
       desc:  'The interface used in SAT',
       xpath: 'source-translation/*/interface-address/interface/text()',
     },
-    SAT_interface_ip: {
+    sat_interface_ip: {
       type:  'Optional[String]',
       desc:  'The interface used in SAT',
       xpath: 'source-translation/*/interface-address/ip/text()',

--- a/spec/unit/puppet/provider/panos_nat_policy/panos_nat_policy_spec.rb
+++ b/spec/unit/puppet/provider/panos_nat_policy/panos_nat_policy_spec.rb
@@ -563,8 +563,8 @@ RSpec.describe Puppet::Provider::PanosNatPolicy::PanosNatPolicy do
         name:                    'Test NAT Policy 9',
         ensure:                  'present',
         source_translation_type: 'dynamic-ip-and-port',
-        SAT_interface:           'tunnel.10',
-        SAT_interface_ip:        '10.10.10.10',
+        sat_interface:           'tunnel.10',
+        sat_interface_ip:        '10.10.10.10',
         from:                    ['sourcezone', 'source_zone'],
         to:                      ['destinationzone', 'destzone'],
         source:                  ['sourceAdr', 'source_adr'],
@@ -701,6 +701,48 @@ RSpec.describe Puppet::Provider::PanosNatPolicy::PanosNatPolicy do
               <to-interface>any</to-interface>
               <nat-type>ipv4</nat-type>
               <disabled>yes</disabled>
+            </entry>',
+    },
+    {
+      desc: 'an example using using SAT interface only',
+      attrs: {
+        name:                    'Test NAT Policy 12',
+        ensure:                  'present',
+        source_translation_type: 'dynamic-ip-and-port',
+        sat_interface:           'tunnel.10',
+        from:                    ['sourcezone', 'source_zone'],
+        to:                      ['destinationzone', 'destzone'],
+        source:                  ['sourceAdr', 'source_adr'],
+        destination:             ['destAdr', 'destination_adr'],
+        service:                 'any',
+        nat_type:                'ipv4',
+      },
+      xml: '<entry name="Test NAT Policy 12">
+              <source-translation>
+                <dynamic-ip-and-port>
+                  <interface-address>
+                    <interface>tunnel.10</interface>
+                  </interface-address>
+                </dynamic-ip-and-port>
+              </source-translation>
+              <to>
+                <member>destinationzone</member>
+                <member>destzone</member>
+              </to>
+              <from>
+                <member>sourcezone</member>
+                <member>source_zone</member>
+              </from>
+              <source>
+                <member>sourceAdr</member>
+                <member>source_adr</member>
+              </source>
+              <destination>
+                <member>destAdr</member>
+                <member>destination_adr</member>
+              </destination>
+              <service>any</service>
+              <nat-type>ipv4</nat-type>
             </entry>',
     },
   ]


### PR DESCRIPTION
This commit changes the attribute names to lowercase as puppet does not support attributes that start with an uppercase
Also set provider to optionally send SAT IP address as it is not required