### PR TITLE
(FM-8104) Add missing `canonicalize` to ipv6 type

### DIFF
--- a/lib/puppet/type/panos_ipv6_static_route.rb
+++ b/lib/puppet/type/panos_ipv6_static_route.rb
@@ -6,7 +6,7 @@ Puppet::ResourceApi.register_type(
 This type provides Puppet with the capabilities to manage IPv6 Static Routes on Palo Alto devices.
 EOS
   base_xpath: '/config/devices/entry/network/virtual-router',
-  features: ['remote_resource'],
+  features: ['remote_resource', 'canonicalize'],
   title_patterns: [
     {
       pattern: %r{^(?<vr_name>[^/]*)/(?<route>.*)$},


### PR DESCRIPTION
Missing this in the type broke the idempotency acceptance test