### PR TITLE
(FM-8015) adding tag to aid with Forge searches

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,12 @@
       "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
+  "tags": [
+    "panos",
+    "palo",
+    "firewall",
+    "network"
+  ],
   "pdk-version": "1.10.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates/#1.10.0",
   "template-ref": "1.10.0-0-gbba9ac3"


### PR DESCRIPTION
adding the "network" tag to the metadata.json - this will allows searches on the Forge to retrieve all "network" related modules - if tagged appropriately.