### PR TITLE
(maint) fixing up the fingerprint hexidigest in the initialize

### DIFF
--- a/lib/puppet/transport/panos.rb
+++ b/lib/puppet/transport/panos.rb
@@ -222,7 +222,7 @@ module Puppet::Transport
       end
 
       def fingerprint_from_hexdigest(hexdigest)
-        hexdigest.tr(' ', '').scan(%r{..}).map { |s| s.upcase }.join(':')
+        hexdigest.tr(':', '').tr(' ', '').scan(%r{..}).map { |s| s.upcase }.join(':')
       end
 
       def http

--- a/spec/unit/puppet/transport/panos_spec.rb
+++ b/spec/unit/puppet/transport/panos_spec.rb
@@ -338,6 +338,13 @@ RSpec.describe Puppet::Transport do
       #       })
     end
 
+    describe '#fingerprint_from_hexdigest' do
+      it { expect(instance.fingerprint_from_hexdigest('fooo:da:ng:er')).to eq('FO:OO:DA:NG:ER') }
+      it { expect(instance.fingerprint_from_hexdigest('d0:0r')).to eq('D0:0R') }
+      it { expect(instance.fingerprint_from_hexdigest('Co oW')).to eq('CO:OW') }
+      it { expect(instance.fingerprint_from_hexdigest('FO:0D')).to eq('FO:0D') }
+    end
+
     describe '#fetch_apikey(user, password)' do
       context 'with valid user and password' do
         it 'fetches the API key' do


### PR DESCRIPTION
Previously a valid hexidigest was getting expanded to have double colon which caused issues when comparing the fingerprint from the device.

This PR will resolve that issue by trimming out the ':'s and then correctly creates the fingerprint