### PR TITLE
(WIP) (MODULES-10385) - Allow vsys to be set

### DIFF
--- a/lib/puppet/provider/panos_address/panos_address.rb
+++ b/lib/puppet/provider/panos_address/panos_address.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_address type using the Resource API.
-class Puppet::Provider::PanosAddress::PanosAddress < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosAddress::PanosAddress < Puppet::Provider::PanosVsysBase
   def validate_should(should)
     required = [should[:ip_netmask], should[:ip_range], should[:fqdn]].compact.size
     if required > 1 # rubocop:disable Style/GuardClause

--- a/lib/puppet/provider/panos_address_group/panos_address_group.rb
+++ b/lib/puppet/provider/panos_address_group/panos_address_group.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_address_group type using the Resource API.
-class Puppet::Provider::PanosAddressGroup::PanosAddressGroup < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosAddressGroup::PanosAddressGroup < Puppet::Provider::PanosVsysBase
   def validate_should(should)
     if should[:type] == 'static' && !should.key?(:static_members)
       raise Puppet::ResourceError, 'Static Address group must provide `static_members`'

--- a/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
+++ b/lib/puppet/provider/panos_nat_policy/panos_nat_policy.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_NAT_policy type using the Resource API.
-class Puppet::Provider::PanosNatPolicy::PanosNatPolicy < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosNatPolicy::PanosNatPolicy < Puppet::Provider::PanosVsysBase
   def munge(entry)
     entry[:bi_directional] = string_to_bool(entry[:bi_directional]) unless entry[:bi_directional].nil?
     entry[:nat_type] = 'ipv4' if entry[:nat_type].nil?

--- a/lib/puppet/provider/panos_security_policy_rule/panos_security_policy_rule.rb
+++ b/lib/puppet/provider/panos_security_policy_rule/panos_security_policy_rule.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_security_policy_rule type using the Resource API.
-class Puppet::Provider::PanosSecurityPolicyRule::PanosSecurityPolicyRule < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosSecurityPolicyRule::PanosSecurityPolicyRule < Puppet::Provider::PanosVsysBase
   def munge(entry)
     none_attrs = [:profile_type, :qos_type]
 

--- a/lib/puppet/provider/panos_service/panos_service.rb
+++ b/lib/puppet/provider/panos_service/panos_service.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_service_type type using the Resource API.
-class Puppet::Provider::PanosService::PanosService < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosService::PanosService < Puppet::Provider::PanosVsysBase
   def xml_from_should(name, should)
     builder = Builder::XmlMarkup.new
     builder.entry('name' => name) do

--- a/lib/puppet/provider/panos_service_group/panos_service_group.rb
+++ b/lib/puppet/provider/panos_service_group/panos_service_group.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_service_group type using the Resource API.
-class Puppet::Provider::PanosServiceGroup::PanosServiceGroup < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosServiceGroup::PanosServiceGroup < Puppet::Provider::PanosVsysBase
   def xml_from_should(name, should)
     builder = Builder::XmlMarkup.new
     builder.entry('name' => name) do

--- a/lib/puppet/provider/panos_tag/panos_tag.rb
+++ b/lib/puppet/provider/panos_tag/panos_tag.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_tags type using the Resource API.
-class Puppet::Provider::PanosTag::PanosTag < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosTag::PanosTag < Puppet::Provider::PanosVsysBase
   def initialize
     super()
     @code_from_color = {

--- a/lib/puppet/provider/panos_vsys_base.rb
+++ b/lib/puppet/provider/panos_vsys_base.rb
@@ -1,0 +1,48 @@
+require_relative 'panos_provider'
+
+# A base provider for all PANOS providers inside a VSYS
+class Puppet::Provider::PanosVsysBase < Puppet::Provider::PanosProvider
+  def get(context)
+    results = []
+    config = context.transport.get_config('/config/devices/entry/vsys/entry')
+    config.elements.collect('/response/result/entry') do |vsys_entry| # rubocop:disable Style/CollectionMethods
+      result = {}
+      vsys = match(vsys_entry, { xpath: 'string(@name)' }, 'name')
+      vsys_entry.elements.collect("/response/result/entry/#{context.type.definition[:base_xpath]}/entry") do |entry| # rubocop:disable Style/CollectionMethods
+        result = {}
+        context.type.attributes.each do |attr_name, attr|
+          result[attr_name] = match(entry, attr, attr_name)
+        end
+        result[:vsys] = vsys
+        results << result
+      end
+    end
+    results
+  end
+
+  def create(context, name, should)
+    validate_should(should) if defined? validate_should
+    xpath = if should[:vsys]
+              "/config/devices/entry/vsys/entry[@name='#{should[:vsys]}']/#{context.type.definition[:base_xpath]}"
+            else
+              "/config/devices/entry/vsys/entry/#{context.type.definition[:base_xpath]}"
+            end
+    context.transport.set_config(xpath, xml_from_should(name, should))
+    context.transport.move(context.type.definition[:base_xpath], name, should[:insert_after]) unless should[:insert_after].nil?
+  end
+
+  def update(context, name, should)
+    validate_should(should) if defined? validate_should
+    xpath = if should[:vsys]
+              "/config/devices/entry/vsys/entry[@name='#{should[:vsys]}']/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']"
+            else
+              "/config/devices/entry/vsys/entry/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']"
+            end
+    context.transport.edit_config(xpath, xml_from_should(name, should))
+    context.transport.move(context.type.definition[:base_xpath], name, should[:insert_after]) unless should[:insert_after].nil?
+  end
+
+  def delete(context, name)
+    context.transport.delete_config("/config/devices/entry/vsys/entry/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']")
+  end
+end

--- a/lib/puppet/provider/panos_vsys_base.rb
+++ b/lib/puppet/provider/panos_vsys_base.rb
@@ -2,6 +2,49 @@ require_relative 'panos_provider'
 
 # A base provider for all PANOS providers inside a VSYS
 class Puppet::Provider::PanosVsysBase < Puppet::Provider::PanosProvider
+  def set(context, changes)
+    changes.each do |name, change|
+      is = if context.type.feature?('simple_get_filter')
+             change.key?(:is) ? change[:is] : (get(context, [name]) || []).find { |r| r[:name] == name }
+           else
+             change.key?(:is) ? change[:is] : (get(context) || []).find { |r| r[:name] == name }
+           end
+      context.type.check_schema(is) unless change.key?(:is)
+
+      should = change[:should]
+
+      raise 'SimpleProvider cannot be used with a Type that is not ensurable' unless context.type.ensurable?
+
+      is = SimpleProvider.create_absent(:name, name) if is.nil?
+      should = SimpleProvider.create_absent(:name, name) if should.nil?
+
+      name_hash = if context.type.namevars.length > 1
+                    # pass a name_hash containing the values of all namevars
+                    name_hash = {}
+                    context.type.namevars.each do |namevar|
+                      name_hash[namevar] = change[:should][namevar]
+                    end
+                    name_hash
+                  else
+                    name
+                  end
+
+      if is[:ensure].to_s == 'absent' && should[:ensure].to_s == 'present'
+        context.creating(name) do
+          create(context, name_hash, should)
+        end
+      elsif is[:ensure].to_s == 'present' && should[:ensure].to_s == 'present'
+        context.updating(name) do
+          update(context, name_hash, should, is)
+        end
+      elsif is[:ensure].to_s == 'present' && should[:ensure].to_s == 'absent'
+        context.deleting(name) do
+          delete(context, name_hash)
+        end
+      end
+    end
+  end
+
   def get(context)
     results = []
     config = context.transport.get_config('/config/devices/entry/vsys/entry')
@@ -31,15 +74,21 @@ class Puppet::Provider::PanosVsysBase < Puppet::Provider::PanosProvider
     context.transport.move(context.type.definition[:base_xpath], name, should[:insert_after]) unless should[:insert_after].nil?
   end
 
-  def update(context, name, should)
+  def update(context, name, should, is)
     validate_should(should) if defined? validate_should
-    xpath = if should[:vsys]
-              "/config/devices/entry/vsys/entry[@name='#{should[:vsys]}']/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']"
-            else
-              "/config/devices/entry/vsys/entry/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']"
-            end
-    context.transport.edit_config(xpath, xml_from_should(name, should))
-    context.transport.move(context.type.definition[:base_xpath], name, should[:insert_after]) unless should[:insert_after].nil?
+    if should[:vsys] == is[:vsys]
+      xpath = if should[:vsys]
+                "/config/devices/entry/vsys/entry[@name='#{should[:vsys]}']/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']"
+              else
+                "/config/devices/entry/vsys/entry/#{context.type.definition[:base_xpath]}/entry[@name='#{name}']"
+              end
+
+      context.transport.edit_config("#{xpath}/entry[@name='#{name}']", xml_from_should(name, should))
+      context.transport.move(context.type.definition[:base_xpath], name, should[:insert_after]) unless should[:insert_after].nil?
+    else
+      delete(context, name)
+      create(context, name, should)
+    end
   end
 
   def delete(context, name)

--- a/lib/puppet/provider/panos_zone/panos_zone.rb
+++ b/lib/puppet/provider/panos_zone/panos_zone.rb
@@ -1,7 +1,7 @@
-require_relative '../panos_provider'
+require_relative '../panos_vsys_base'
 
 # Implementation for the panos_tags type using the Resource API.
-class Puppet::Provider::PanosZone::PanosZone < Puppet::Provider::PanosProvider
+class Puppet::Provider::PanosZone::PanosZone < Puppet::Provider::PanosVsysBase
   def munge(entry)
     bool_attrs = [:enable_user_identification, :enable_packet_buffer_protection, :nsx_service_profile]
     bool_attrs.each do |attr|

--- a/lib/puppet/type/panos_address.rb
+++ b/lib/puppet/type/panos_address.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "address" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/address',
+  base_xpath: 'address',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -13,6 +13,10 @@ EOS
       desc:      'The display-name of the address.',
       behaviour: :namevar,
       xpath:     'string(@name)',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the addresses xpath.',
     },
     ensure: {
       type:    'Enum[present, absent]',

--- a/lib/puppet/type/panos_address_group.rb
+++ b/lib/puppet/type/panos_address_group.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "address_groups" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/address-group',
+  base_xpath: 'address-group',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -18,6 +18,10 @@ EOS
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the address groups xpath.',
     },
     description: {
       type:      'Optional[String]',

--- a/lib/puppet/type/panos_nat_policy.rb
+++ b/lib/puppet/type/panos_nat_policy.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "NAT Policy Rule" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/rulebase/nat/rules',
+  base_xpath: 'rulebase/nat/rules',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -23,6 +23,10 @@ EOS
       type:  'Optional[String]',
       desc:  'A description of the NAT Policy Rule',
       xpath: 'description/text()',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the policies xpath.',
     },
     nat_type: {
       type:    'Enum["ipv4", "nat64", "nptv6"]',

--- a/lib/puppet/type/panos_security_policy_rule.rb
+++ b/lib/puppet/type/panos_security_policy_rule.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capilities to manage "Security Policy Rules" on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/rulebase/security/rules',
+  base_xpath: 'rulebase/security/rules',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -18,6 +18,10 @@ EOS
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the rules xpath.',
     },
     rule_type: {
       type:    'Enum["universal", "interzone", "intrazone"]',

--- a/lib/puppet/type/panos_service.rb
+++ b/lib/puppet/type/panos_service.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "service" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/service',
+  base_xpath: 'service',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -23,6 +23,10 @@ EOS
       type:  'Optional[String]',
       desc:  'Provide a description of this service.',
       xpath: 'description/text()',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the services xpath.',
     },
     protocol: {
       type:    'Enum["tcp", "udp"]',

--- a/lib/puppet/type/panos_service_group.rb
+++ b/lib/puppet/type/panos_service_group.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "Service Group" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/service-group',
+  base_xpath: 'service-group',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -18,6 +18,10 @@ EOS
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the service groups xpath.',
     },
     services: {
       type:         'Array[String]',

--- a/lib/puppet/type/panos_tag.rb
+++ b/lib/puppet/type/panos_tag.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "tags" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/tag',
+  base_xpath: 'tag',
   features: ['remote_resource', 'canonicalize'],
   attributes: {
     name: {
@@ -18,6 +18,10 @@ EOS
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the tags xpath.',
     },
     color: {
       type:  'Optional[String]',

--- a/lib/puppet/type/panos_zone.rb
+++ b/lib/puppet/type/panos_zone.rb
@@ -5,7 +5,7 @@ Puppet::ResourceApi.register_type(
   docs: <<-EOS,
 This type provides Puppet with the capabilities to manage "zone" objects on Palo Alto devices.
 EOS
-  base_xpath: '/config/devices/entry/vsys/entry/zone',
+  base_xpath: 'zone',
   features: ['remote_resource'],
   attributes: {
     name: {
@@ -18,6 +18,10 @@ EOS
       type:    'Enum[present, absent]',
       desc:    'Whether this resource should be present or absent on the target system.',
       default: 'present',
+    },
+    vsys: {
+      type:      'Optional[String]',
+      desc:      'The vsys of the zones xpath.',
     },
     network: {
       type:    'Enum["tap", "virtual-wire", "layer2", "layer3", "tunnel"]',


### PR DESCRIPTION
Note: In regards to naming conventions for the various types for which the vsys can be set, we are moving forward with the assumption that names must be unique across all separate vsys, not just within them as that is what is indicated within the following document: https://docs.paloaltonetworks.com/pan-os/7-1/pan-os-web-interface-help/objects/objects-addresses

PR has been recreated, see PR linked below for a history of changes made:
https://github.com/puppetlabs/puppetlabs-panos/pull/119
